### PR TITLE
[MetaxGPU][TileOps] fix incorrect results for MaximumOp and MinimumOp on fp16/bf16

### DIFF
--- a/src/target/codegen_maca.cc
+++ b/src/target/codegen_maca.cc
@@ -890,21 +890,25 @@ std::string CodeGenTileLangMACA::CastFromTo(std::string value, DataType from,
   if (from == target)
     return value;
   std::ostringstream os;
-  os << "((";
-  this->PrintType(target, os);
-  os << ")";
-  if (from.is_float16() && (target.is_int() || target.is_uint()) &&
-      target.bits() == 8) {
-    os << "(";
-    if (target.is_uint()) {
-      os << "u";
+  if (from.is_float8() && target.is_float16()) {
+    os << "__cvt_fp8_to_half(" << value << ")";
+  } else {
+    os << "((";
+    this->PrintType(target, os);
+    os << ")";
+    if (from.is_float16() && (target.is_int() || target.is_uint()) &&
+        target.bits() == 8) {
+        os << "(";
+        if (target.is_uint()) {
+            os << "u";
+        }
+        os << "int)";
     }
-    os << "int)";
+    if ((from.is_float16() || from.is_bfloat16()) && target.is_float8()) {
+        os << "(float)";
+    }
+    os << value << ")";
   }
-  if ((from.is_float16() || from.is_bfloat16()) && target.is_float8()) {
-    os << "(float)";
-  }
-  os << value << ")";
   return os.str();
 }
 
@@ -1796,6 +1800,8 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
         {"float16x4", "float16x4"},
         {"bfloat16x4", "bfloat16x4_vec"},
         {"float32x4", "float32x4"},
+        {"float8_e4m3", "fp8_e4_t"},
+        {"float8_e5m2", "fp8_e5_t"}
         {"float8_e4m3fnuzx4", "fp8_e4_4_t"},
         {"float8_e4m3fnuzx8", "long"},
         {"float32x16", "float32x16"}};

--- a/src/target/codegen_maca.cc
+++ b/src/target/codegen_maca.cc
@@ -1178,8 +1178,8 @@ void CodeGenTileLangMACA::VisitExpr_(const MinNode *op, std::ostream &os) {
 
   // Standard min/max functions don't support bfloat16 or float16
   if ((t.is_bfloat16() || t.is_float16()) && t.is_scalar()) {
-    os << "mctlass::fast_min(" << PrintExpr(op->a) << ", " << PrintExpr(op->b)
-       << ")";
+    os << "mctlass::fast_min(" << "(float)" << PrintExpr(op->a) << ", "
+       << "(float)" << PrintExpr(op->b) << ")";
     return;
   }
 
@@ -1201,8 +1201,8 @@ void CodeGenTileLangMACA::VisitExpr_(const MaxNode *op, std::ostream &os) {
 
   // Standard min/max functions don't support bfloat16 or float16
   if ((t.is_bfloat16() || t.is_float16()) && t.is_scalar()) {
-    os << "mctlass::fast_max(" << PrintExpr(op->a) << ", " << PrintExpr(op->b)
-       << ")";
+    os << "mctlass::fast_max(" << "(float)" << PrintExpr(op->a) << ", "
+       << "(float)" << PrintExpr(op->b) << ")";
     return;
   }
 

--- a/src/target/codegen_maca.cc
+++ b/src/target/codegen_maca.cc
@@ -890,25 +890,18 @@ std::string CodeGenTileLangMACA::CastFromTo(std::string value, DataType from,
   if (from == target)
     return value;
   std::ostringstream os;
-  if (from.is_float8() && target.is_float16()) {
-    os << "__cvt_fp8_to_half(" << value << ")";
-  } else {
-    os << "((";
-    this->PrintType(target, os);
-    os << ")";
-    if (from.is_float16() && (target.is_int() || target.is_uint()) &&
-        target.bits() == 8) {
-      os << "(";
-      if (target.is_uint()) {
-        os << "u";
-      }
-      os << "int)";
+  os << "((";
+  this->PrintType(target, os);
+  os << ")";
+  if (from.is_float16() && (target.is_int() || target.is_uint()) &&
+      target.bits() == 8) {
+    os << "(";
+    if (target.is_uint()) {
+      os << "u";
     }
-    if ((from.is_float16() || from.is_bfloat16()) && target.is_float8()) {
-      os << "(float)";
-    }
-    os << value << ")";
+    os << "int)";
   }
+  os << value << ")";
   return os.str();
 }
 
@@ -1800,8 +1793,6 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
         {"float16x4", "float16x4"},
         {"bfloat16x4", "bfloat16x4_vec"},
         {"float32x4", "float32x4"},
-        {"float8_e4m3", "fp8_e4_t"},
-        {"float8_e5m2", "fp8_e5_t"},
         {"float8_e4m3fnuzx4", "fp8_e4_4_t"},
         {"float8_e4m3fnuzx8", "long"},
         {"float32x16", "float32x16"}};

--- a/src/target/codegen_maca.cc
+++ b/src/target/codegen_maca.cc
@@ -898,14 +898,14 @@ std::string CodeGenTileLangMACA::CastFromTo(std::string value, DataType from,
     os << ")";
     if (from.is_float16() && (target.is_int() || target.is_uint()) &&
         target.bits() == 8) {
-        os << "(";
-        if (target.is_uint()) {
-            os << "u";
-        }
-        os << "int)";
+      os << "(";
+      if (target.is_uint()) {
+        os << "u";
+      }
+      os << "int)";
     }
     if ((from.is_float16() || from.is_bfloat16()) && target.is_float8()) {
-        os << "(float)";
+      os << "(float)";
     }
     os << value << ")";
   }
@@ -1801,8 +1801,7 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
         {"bfloat16x4", "bfloat16x4_vec"},
         {"float32x4", "float32x4"},
         {"float8_e4m3", "fp8_e4_t"},
-        {"float8_e5m2", "fp8_e5_t"}
-        {"float8_e4m3fnuzx4", "fp8_e4_4_t"},
+        {"float8_e5m2", "fp8_e5_t"} {"float8_e4m3fnuzx4", "fp8_e4_4_t"},
         {"float8_e4m3fnuzx8", "long"},
         {"float32x16", "float32x16"}};
     std::string call_mfma_code = R"({

--- a/src/target/codegen_maca.cc
+++ b/src/target/codegen_maca.cc
@@ -1801,7 +1801,8 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
         {"bfloat16x4", "bfloat16x4_vec"},
         {"float32x4", "float32x4"},
         {"float8_e4m3", "fp8_e4_t"},
-        {"float8_e5m2", "fp8_e5_t"} {"float8_e4m3fnuzx4", "fp8_e4_4_t"},
+        {"float8_e5m2", "fp8_e5_t"},
+        {"float8_e4m3fnuzx4", "fp8_e4_4_t"},
         {"float8_e4m3fnuzx8", "long"},
         {"float32x16", "float32x16"}};
     std::string call_mfma_code = R"({

--- a/src/tl_templates/maca/maca_fp8.h
+++ b/src/tl_templates/maca/maca_fp8.h
@@ -305,59 +305,60 @@ __tl_cvt_fp8x2_to_float2(const __maca_fp8x2_storage_t x,
 
 // e4m3 -> half
 TL_DEVICE half_t __cvt_fp8_to_half(fp8_e4_t x) {
-    half_t res;
-    res.storage = 0U;
-    unsigned short int ur = (unsigned short int)x.__x;
-    ur = (unsigned short int)(ur << 8U);
+  half_t res;
+  res.storage = 0U;
+  unsigned short int ur = (unsigned short int)x.__x;
+  ur = (unsigned short int)(ur << 8U);
 
-    // __MACA_E4M3
-    unsigned short int sign = ur & 0x8000U;
-    unsigned short int exponent = (unsigned short int)(((ur & 0x7800U) >> 1U) + 0x2000U);
-    unsigned short int mantissa = (ur & 0x0700U) >> 1U;
-    unsigned char absx = 0x7FU & (unsigned char)x.__x;
-    if (absx == 0x7FU) {// NaN
-        ur = 0x7FFFU; // fp16 canonical NaN, discard sign
-    } else if (exponent == 0x2000U) {
-        // zero or denormal
-        if (mantissa != 0U) {
-            // normalize
-            mantissa = (unsigned short int)(mantissa << 1U);
-            while ((mantissa & 0x0400U) == 0U) {
-                mantissa = (unsigned short int)(mantissa << 1U);
-                exponent = (unsigned short int)(exponent - 0x0400U);
-            }
-            // discard implicit leading bit
-            mantissa &= 0x03FFU;
-        } else { // Zero
-            exponent = 0U;
-        }
-        ur = (sign | exponent) | mantissa;
-    } else {
-        ur = (sign | exponent) | mantissa;
+  // __MACA_E4M3
+  unsigned short int sign = ur & 0x8000U;
+  unsigned short int exponent =
+      (unsigned short int)(((ur & 0x7800U) >> 1U) + 0x2000U);
+  unsigned short int mantissa = (ur & 0x0700U) >> 1U;
+  unsigned char absx = 0x7FU & (unsigned char)x.__x;
+  if (absx == 0x7FU) { // NaN
+    ur = 0x7FFFU;      // fp16 canonical NaN, discard sign
+  } else if (exponent == 0x2000U) {
+    // zero or denormal
+    if (mantissa != 0U) {
+      // normalize
+      mantissa = (unsigned short int)(mantissa << 1U);
+      while ((mantissa & 0x0400U) == 0U) {
+        mantissa = (unsigned short int)(mantissa << 1U);
+        exponent = (unsigned short int)(exponent - 0x0400U);
+      }
+      // discard implicit leading bit
+      mantissa &= 0x03FFU;
+    } else { // Zero
+      exponent = 0U;
     }
+    ur = (sign | exponent) | mantissa;
+  } else {
+    ur = (sign | exponent) | mantissa;
+  }
 
-    res.storage = ur;
-    return res;
+  res.storage = ur;
+  return res;
 }
 
 // e5m2 -> half
 TL_DEVICE half_t __cvt_fp8_to_half(fp8_e5_t x) {
-    half_t res;
-    res.storage = 0U;
-    unsigned short int ur = (unsigned short int)x.__x;
-    ur = (unsigned short int)(ur << 8U);
+  half_t res;
+  res.storage = 0U;
+  unsigned short int ur = (unsigned short int)x.__x;
+  ur = (unsigned short int)(ur << 8U);
 
-    // FP8 e5m2 -> FP16 half bits
-    unsigned short int sign     = ur & 0x8000U; // bit15
-    unsigned short int exponent = ur & 0x7C00U; // bits14..10 (5-bit exp)
-    unsigned short int mantissa = ur & 0x0300U; // bits9..8 (2-bit mantissa)
+  // FP8 e5m2 -> FP16 half bits
+  unsigned short int sign = ur & 0x8000U;     // bit15
+  unsigned short int exponent = ur & 0x7C00U; // bits14..10 (5-bit exp)
+  unsigned short int mantissa = ur & 0x0300U; // bits9..8 (2-bit mantissa)
 
-    if ((exponent == 0x7C00U) && (mantissa != 0)) {
-        mantissa |= 0x0200U; // quiet bit: half mantissa bit9
-    }
+  if ((exponent == 0x7C00U) && (mantissa != 0)) {
+    mantissa |= 0x0200U; // quiet bit: half mantissa bit9
+  }
 
-    ur = (sign | exponent) | mantissa;
+  ur = (sign | exponent) | mantissa;
 
-    res.storage = ur;
-    return res;
+  res.storage = ur;
+  return res;
 }

--- a/src/tl_templates/maca/maca_fp8.h
+++ b/src/tl_templates/maca/maca_fp8.h
@@ -3,8 +3,235 @@
 #include "common.h"
 #include <maca_fp8.h>
 
-using fp8_e4_t = __maca_fp8_e4m3;
-using fp8_e5_t = __maca_fp8_e5m2;
+TL_DEVICE half_t __cvt_fp8_e4m3_to_half(__maca_fp8_e4m3 x) {
+  uint16_t bits = (uint16_t)x.__x;
+  bits = (uint16_t)(bits << 8U);
+
+  uint16_t sign = bits & 0x8000U;
+  uint16_t exponent = (uint16_t)(((bits & 0x7800U) >> 1U) + 0x2000U);
+  uint16_t mantissa = (bits & 0x0700U) >> 1U;
+  unsigned char absx = 0x7FU & (unsigned char)x.__x;
+
+  if (absx == 0x7FU) { // NaN
+    bits = 0x7FFFU;    // fp16 canonical NaN, discard sign
+  } else if (exponent == 0x2000U) {
+    // zero or denormal
+    if (mantissa != 0U) {
+      // normalize
+      mantissa = (uint16_t)(mantissa << 1U);
+      while ((mantissa & 0x0400U) == 0U) {
+        mantissa = (uint16_t)(mantissa << 1U);
+        exponent = (uint16_t)(exponent - 0x0400U);
+      }
+      // discard implicit leading bit
+      mantissa &= 0x03FFU;
+    } else { // Zero
+      exponent = 0U;
+    }
+    bits = (sign | exponent) | mantissa;
+  } else {
+    bits = (sign | exponent) | mantissa;
+  }
+
+  return *reinterpret_cast<half_t *>(&bits);
+}
+
+TL_DEVICE float __cvt_fp8_e4m3_to_float(__maca_fp8_e4m3 x) {
+  uint32_t bits;
+  uint32_t sign = ((uint32_t)x.__x & 0x80U) << 24;
+  uint32_t exp4 = ((uint32_t)x.__x >> 3) & 0x0FU;
+  uint32_t man3 = (uint32_t)x.__x & 0x07U;
+
+  if (exp4 == 0U) {
+    /* ±0 or subnormal: value = (-1)^s * man3 * 2^-9 */
+    if (man3 == 0U) {
+      bits = sign; /* ±0 */
+    } else {
+      switch (man3) {
+      case 1U:                      /* 1 * 2^-9  */
+        bits = sign | (118U << 23); /* 1.0 * 2^-9 */
+        break;
+      case 2U:                      /* 2 * 2^-9  */
+        bits = sign | (119U << 23); /* 1.0 * 2^-8 */
+        break;
+      case 3U:                                  /* 3 * 2^-9  */
+        bits = sign | (119U << 23) | 0x400000U; /* 1.5 * 2^-8 */
+        break;
+      case 4U:                      /* 4 * 2^-9  */
+        bits = sign | (120U << 23); /* 1.0 * 2^-7 */
+        break;
+      case 5U:                                  /* 5 * 2^-9  */
+        bits = sign | (120U << 23) | 0x200000U; /* 1.25 * 2^-7 */
+        break;
+      case 6U:                                  /* 6 * 2^-9  */
+        bits = sign | (120U << 23) | 0x400000U; /* 1.5 * 2^-7 */
+        break;
+      case 7U:                                  /* 7 * 2^-9  */
+        bits = sign | (120U << 23) | 0x600000U; /* 1.75 * 2^-7 */
+        break;
+      default:
+        bits = sign;
+        break;
+      }
+    }
+  } else if (exp4 == 15U) {
+    if (man3 == 7U) {
+      /* quiet NaN */
+      bits = sign | 0x7FC00000U;
+    } else {
+      /* normal decode: value = (-1)^s * (1 + man3/8) * 2^(exp4-7)
+      float32: exp32 = (exp4-7)+127 = exp4+120, mant32 = man3 << 20 */
+      bits = sign | ((exp4 + 120U) << 23) | (man3 << 20);
+    }
+  } else {
+    /* 1 <= exp4 <= 14：normal decode */
+    bits = sign | ((exp4 + 120U) << 23) | (man3 << 20);
+  }
+
+  return *reinterpret_cast<float *>(&bits);
+}
+
+struct fp8_e4_t {
+  using value_t = __maca_fp8_e4m3;
+  value_t v;
+
+  TL_DEVICE constexpr fp8_e4_t() : v{} {}
+
+  TL_DEVICE explicit fp8_e4_t(value_t x) : v(x) {}
+
+  template <class T,
+            std::enable_if_t<!std::is_same_v<std::decay_t<T>, fp8_e4_t> &&
+                                 std::is_constructible_v<value_t, T>,
+                             int> = 0>
+  TL_DEVICE explicit fp8_e4_t(T &&x) : v(std::forward<T>(x)) {}
+
+  TL_DEVICE operator half_t() const { return __cvt_fp8_e4m3_to_half(v); }
+
+  TL_DEVICE operator float() const { return __cvt_fp8_e4m3_to_float(v); }
+
+private:
+  template <class To, class = void>
+  struct is_static_castable : std::false_type {};
+  template <class To>
+  struct is_static_castable<
+      To, std::void_t<decltype(static_cast<To>(std::declval<value_t>()))>>
+      : std::true_type {};
+
+public:
+  template <class To,
+            std::enable_if_t<!std::is_same_v<std::decay_t<To>, half_t> &&
+                                 !std::is_same_v<std::decay_t<To>, float> &&
+                                 !std::is_same_v<std::decay_t<To>, value_t> &&
+                                 !std::is_same_v<std::decay_t<To>, fp8_e4_t> &&
+                                 is_static_castable<To>::value,
+                             int> = 0>
+  TL_DEVICE operator To() const {
+    return static_cast<To>(v);
+  }
+};
+
+TL_DEVICE half_t __cvt_fp8_e5m2_to_half(__maca_fp8_e5m2 x) {
+  uint16_t bits = (uint16_t)x.__x;
+  bits = (uint16_t)(bits << 8U);
+
+  // FP8 e5m2 -> FP16 half bits
+  uint16_t sign = bits & 0x8000U;     // bit15
+  uint16_t exponent = bits & 0x7C00U; // bits14..10 (5-bit exp)
+  uint16_t mantissa = bits & 0x0300U; // bits9..8 (2-bit mantissa)
+
+  if ((exponent == 0x7C00U) && (mantissa != 0)) {
+    mantissa |= 0x0200U; // quiet bit: half mantissa bit9
+  }
+
+  bits = (sign | exponent) | mantissa;
+
+  return *reinterpret_cast<half_t *>(&bits);
+}
+
+TL_DEVICE float __cvt_fp8_e5m2_to_float(__maca_fp8_e5m2 x) {
+  uint32_t bits;
+  uint32_t sign = ((uint32_t)x.__x & 0x80U) << 24;
+  uint32_t exp8 = ((uint32_t)x.__x >> 2) & 0x1FU;
+  uint32_t man8 = (uint32_t)x.__x & 0x03U;
+
+  if (exp8 == 0U) {
+    if (man8 == 0U) {
+      bits = sign;
+    } else {
+      uint32_t exp32, man32;
+      switch (man8) {
+      case 1U:              /* 1 * 2^-16 */
+        exp32 = 127U - 16U; /* 111 */
+        man32 = 0U;
+        break;
+      case 2U:              /* 2 * 2^-16 = 2^-15 */
+        exp32 = 127U - 15U; /* 112 */
+        man32 = 0U;
+        break;
+      case 3U:              /* 3 * 2^-16 = 1.5 * 2^-15 */
+        exp32 = 127U - 15U; /* 112 */
+        man32 = 0x400000U;
+        break;
+      default:
+        exp32 = 0U;
+        man32 = 0U;
+        break;
+      }
+      bits = sign | (exp32 << 23) | man32;
+    }
+  } else if (exp8 == 31U) {
+    if (man8 == 0U) {
+      bits = sign | 0x7F800000U; /* ±Inf */
+    } else {
+      bits = sign | 0x7F800000U | (man8 << 21);
+    }
+  } else {
+    uint32_t exp32 = exp8 + 112U;
+    uint32_t man32 = man8 << 21U;
+    bits = sign | (exp32 << 23) | man32;
+  }
+
+  return *reinterpret_cast<float *>(&bits);
+}
+
+struct fp8_e5_t {
+  using value_t = __maca_fp8_e5m2;
+  value_t v;
+
+  TL_DEVICE constexpr fp8_e5_t() : v{} {}
+
+  TL_DEVICE explicit fp8_e5_t(value_t x) : v(x) {}
+
+  template <class T,
+            std::enable_if_t<!std::is_same_v<std::decay_t<T>, fp8_e5_t> &&
+                                 std::is_constructible_v<value_t, T>,
+                             int> = 0>
+  TL_DEVICE explicit fp8_e5_t(T &&x) : v(std::forward<T>(x)) {}
+
+  TL_DEVICE operator half_t() const { return __cvt_fp8_e5m2_to_half(v); }
+
+  TL_DEVICE operator float() const { return __cvt_fp8_e5m2_to_float(v); }
+
+private:
+  template <class To, class = void>
+  struct is_static_castable : std::false_type {};
+  template <class To>
+  struct is_static_castable<
+      To, std::void_t<decltype(static_cast<To>(std::declval<value_t>()))>>
+      : std::true_type {};
+
+public:
+  template <class To,
+            std::enable_if_t<!std::is_same_v<std::decay_t<To>, half_t> &&
+                                 !std::is_same_v<std::decay_t<To>, float> &&
+                                 !std::is_same_v<std::decay_t<To>, value_t> &&
+                                 !std::is_same_v<std::decay_t<To>, fp8_e5_t> &&
+                                 is_static_castable<To>::value,
+                             int> = 0>
+  TL_DEVICE operator To() const {
+    return static_cast<To>(v);
+  }
+};
 
 struct fp8_e8_t {
   unsigned char data;
@@ -292,73 +519,58 @@ TL_DEVICE fp8_e8_32_t make_fp8_e8_32_t(
   return result;
 }
 
+TL_DEVICE float __tl_decode_fp8_e4m3_to_float(unsigned char bits) {
+  const float sign = (bits & 0x80) ? -1.0f : 1.0f;
+  const int exponent = (bits >> 3) & 0x0f;
+  const int mantissa = bits & 0x07;
+
+  if (exponent == 0) {
+    if (mantissa == 0) {
+      return (bits & 0x80) ? MACART_NEG_ZERO_F : 0.0f;
+    }
+    return sign * ldexpf(static_cast<float>(mantissa), -9);
+  }
+  if (exponent == 0x0f && mantissa == 0x07) {
+    return MACART_NAN_F;
+  }
+
+  return sign * ldexpf(1.0f + static_cast<float>(mantissa) * (1.0f / 8.0f),
+                       exponent - 7);
+}
+
+TL_DEVICE float __tl_decode_fp8_e5m2_to_float(unsigned char bits) {
+  const float sign = (bits & 0x80) ? -1.0f : 1.0f;
+  const int exponent = (bits >> 2) & 0x1f;
+  const int mantissa = bits & 0x03;
+  if (exponent == 0) {
+    if (mantissa == 0) {
+      return (bits & 0x80) ? MACART_NEG_ZERO_F : 0.0f;
+    }
+    return sign * ldexpf(static_cast<float>(mantissa), -16);
+  }
+  if (exponent == 0x1f) {
+    if (mantissa == 0) {
+      return (bits & 0x80) ? MACART_NEGINF_F : MACART_INF_F;
+    }
+    return MACART_NAN_F;
+  }
+  return sign *
+         ldexpf(1.0f + static_cast<float>(mantissa) * 0.25f, exponent - 15);
+}
+
 // e4m3x2 -> float2
 TL_DEVICE float2
 __tl_cvt_fp8x2_to_float2(const __maca_fp8x2_storage_t x,
                          const __maca_fp8_interpretation_t fp8_interpretation) {
-  half2 tmp = __maca_cvt_fp8x2_to_halfraw2(x, fp8_interpretation);
+  const unsigned char lo = static_cast<unsigned char>(x & 0xff);
+  const unsigned char hi = static_cast<unsigned char>((x >> 8) & 0xff);
   float2 result;
-  result.x = (float)tmp.x;
-  result.y = (float)tmp.y;
-  return result;
-}
-
-// e4m3 -> half
-TL_DEVICE half_t __cvt_fp8_to_half(fp8_e4_t x) {
-  half_t res;
-  res.storage = 0U;
-  unsigned short int ur = (unsigned short int)x.__x;
-  ur = (unsigned short int)(ur << 8U);
-
-  // __MACA_E4M3
-  unsigned short int sign = ur & 0x8000U;
-  unsigned short int exponent =
-      (unsigned short int)(((ur & 0x7800U) >> 1U) + 0x2000U);
-  unsigned short int mantissa = (ur & 0x0700U) >> 1U;
-  unsigned char absx = 0x7FU & (unsigned char)x.__x;
-  if (absx == 0x7FU) { // NaN
-    ur = 0x7FFFU;      // fp16 canonical NaN, discard sign
-  } else if (exponent == 0x2000U) {
-    // zero or denormal
-    if (mantissa != 0U) {
-      // normalize
-      mantissa = (unsigned short int)(mantissa << 1U);
-      while ((mantissa & 0x0400U) == 0U) {
-        mantissa = (unsigned short int)(mantissa << 1U);
-        exponent = (unsigned short int)(exponent - 0x0400U);
-      }
-      // discard implicit leading bit
-      mantissa &= 0x03FFU;
-    } else { // Zero
-      exponent = 0U;
-    }
-    ur = (sign | exponent) | mantissa;
+  if (fp8_interpretation == __MACA_E4M3) {
+    result.x = __tl_decode_fp8_e4m3_to_float(lo);
+    result.y = __tl_decode_fp8_e4m3_to_float(hi);
   } else {
-    ur = (sign | exponent) | mantissa;
+    result.x = __tl_decode_fp8_e5m2_to_float(lo);
+    result.y = __tl_decode_fp8_e5m2_to_float(hi);
   }
-
-  res.storage = ur;
-  return res;
-}
-
-// e5m2 -> half
-TL_DEVICE half_t __cvt_fp8_to_half(fp8_e5_t x) {
-  half_t res;
-  res.storage = 0U;
-  unsigned short int ur = (unsigned short int)x.__x;
-  ur = (unsigned short int)(ur << 8U);
-
-  // FP8 e5m2 -> FP16 half bits
-  unsigned short int sign = ur & 0x8000U;     // bit15
-  unsigned short int exponent = ur & 0x7C00U; // bits14..10 (5-bit exp)
-  unsigned short int mantissa = ur & 0x0300U; // bits9..8 (2-bit mantissa)
-
-  if ((exponent == 0x7C00U) && (mantissa != 0)) {
-    mantissa |= 0x0200U; // quiet bit: half mantissa bit9
-  }
-
-  ur = (sign | exponent) | mantissa;
-
-  res.storage = ur;
-  return res;
+  return result;
 }

--- a/src/tl_templates/maca/maca_fp8.h
+++ b/src/tl_templates/maca/maca_fp8.h
@@ -302,3 +302,62 @@ __tl_cvt_fp8x2_to_float2(const __maca_fp8x2_storage_t x,
   result.y = (float)tmp.y;
   return result;
 }
+
+// e4m3 -> half
+TL_DEVICE half_t __cvt_fp8_to_half(fp8_e4_t x) {
+    half_t res;
+    res.storage = 0U;
+    unsigned short int ur = (unsigned short int)x.__x;
+    ur = (unsigned short int)(ur << 8U);
+
+    // __MACA_E4M3
+    unsigned short int sign = ur & 0x8000U;
+    unsigned short int exponent = (unsigned short int)(((ur & 0x7800U) >> 1U) + 0x2000U);
+    unsigned short int mantissa = (ur & 0x0700U) >> 1U;
+    unsigned char absx = 0x7FU & (unsigned char)x.__x;
+    if (absx == 0x7FU) {// NaN
+        ur = 0x7FFFU; // fp16 canonical NaN, discard sign
+    } else if (exponent == 0x2000U) {
+        // zero or denormal
+        if (mantissa != 0U) {
+            // normalize
+            mantissa = (unsigned short int)(mantissa << 1U);
+            while ((mantissa & 0x0400U) == 0U) {
+                mantissa = (unsigned short int)(mantissa << 1U);
+                exponent = (unsigned short int)(exponent - 0x0400U);
+            }
+            // discard implicit leading bit
+            mantissa &= 0x03FFU;
+        } else { // Zero
+            exponent = 0U;
+        }
+        ur = (sign | exponent) | mantissa;
+    } else {
+        ur = (sign | exponent) | mantissa;
+    }
+
+    res.storage = ur;
+    return res;
+}
+
+// e5m2 -> half
+TL_DEVICE half_t __cvt_fp8_to_half(fp8_e5_t x) {
+    half_t res;
+    res.storage = 0U;
+    unsigned short int ur = (unsigned short int)x.__x;
+    ur = (unsigned short int)(ur << 8U);
+
+    // FP8 e5m2 -> FP16 half bits
+    unsigned short int sign     = ur & 0x8000U; // bit15
+    unsigned short int exponent = ur & 0x7C00U; // bits14..10 (5-bit exp)
+    unsigned short int mantissa = ur & 0x0300U; // bits9..8 (2-bit mantissa)
+
+    if ((exponent == 0x7C00U) && (mantissa != 0)) {
+        mantissa |= 0x0200U; // quiet bit: half mantissa bit9
+    }
+
+    ur = (sign | exponent) | mantissa;
+
+    res.storage = ur;
+    return res;
+}


### PR DESCRIPTION
Fix incorrect results for MaximumOp and MinimumOp in fp16/bf16 types.
- Address the lack of fp16/bf16 template specialization in mctlass::fast_max/min.
- Cast inputs to float32 when calling MCTLAS math functions to ensure correctness.