### PR TITLE
[MetaxGPU][TileOps] Fix incorrect results for MaximumOp and MinimumOp on fp16/bf16

### DIFF
--- a/src/target/codegen_maca.cc
+++ b/src/target/codegen_maca.cc
@@ -1178,8 +1178,8 @@ void CodeGenTileLangMACA::VisitExpr_(const MinNode *op, std::ostream &os) {
 
   // Standard min/max functions don't support bfloat16 or float16
   if ((t.is_bfloat16() || t.is_float16()) && t.is_scalar()) {
-    os << "mctlass::fast_min(" << PrintExpr(op->a) << ", " << PrintExpr(op->b)
-       << ")";
+    os << "mctlass::fast_min(" << "(float)" << PrintExpr(op->a) << ", "
+       << "(float)" << PrintExpr(op->b) << ")";
     return;
   }
 
@@ -1201,8 +1201,8 @@ void CodeGenTileLangMACA::VisitExpr_(const MaxNode *op, std::ostream &os) {
 
   // Standard min/max functions don't support bfloat16 or float16
   if ((t.is_bfloat16() || t.is_float16()) && t.is_scalar()) {
-    os << "mctlass::fast_max(" << PrintExpr(op->a) << ", " << PrintExpr(op->b)
-       << ")";
+    os << "mctlass::fast_max(" << "(float)" << PrintExpr(op->a) << ", "
+       << "(float)" << PrintExpr(op->b) << ")";
     return;
   }
 

--- a/src/target/codegen_maca.cc
+++ b/src/target/codegen_maca.cc
@@ -1178,8 +1178,7 @@ void CodeGenTileLangMACA::VisitExpr_(const MinNode *op, std::ostream &os) {
 
   // Standard min/max functions don't support bfloat16 or float16
   if ((t.is_bfloat16() || t.is_float16()) && t.is_scalar()) {
-    os << "mctlass::fast_min(" << "(float)" << PrintExpr(op->a) << ", "
-       << "(float)" << PrintExpr(op->b) << ")";
+    os << "__hmin(" << PrintExpr(op->a) << ", " << PrintExpr(op->b) << ")";
     return;
   }
 
@@ -1201,8 +1200,7 @@ void CodeGenTileLangMACA::VisitExpr_(const MaxNode *op, std::ostream &os) {
 
   // Standard min/max functions don't support bfloat16 or float16
   if ((t.is_bfloat16() || t.is_float16()) && t.is_scalar()) {
-    os << "mctlass::fast_max(" << "(float)" << PrintExpr(op->a) << ", "
-       << "(float)" << PrintExpr(op->b) << ")";
+    os << "__hmax(" << PrintExpr(op->a) << ", " << PrintExpr(op->b) << ")";
     return;
   }
 


### PR DESCRIPTION
Fix incorrect results for MaximumOp and MinimumOp in fp16/bf16 types.

Address the lack of fp16/bf16 template specialization in mctlass::fast_max/min.
Cast inputs to float32 when calling MCTLAS math functions to ensure correctness.