### PR TITLE
Remove the stale MACA fusedmoe xfail and synchronize cython multi-stream JIT coverage

### DIFF
--- a/examples/maca/fusedmoe/test_example_fusedmoe.py
+++ b/examples/maca/fusedmoe/test_example_fusedmoe.py
@@ -2,7 +2,6 @@ import tilelang.testing
 import example_fusedmoe_tilelang
 
 
-@tilelang.testing.pytest.mark.xfail
 def test_example_fusedmoe_tilelang():
     example_fusedmoe_tilelang.main(
         d_hidden=1024, d_expert=256, n_routed_experts=8, n_shared_experts=1, n_experts_per_token=4, batch_size=1, seq_len=1024

--- a/testing/python/jit/test_tilelang_jit_gemm_cython.py
+++ b/testing/python/jit/test_tilelang_jit_gemm_cython.py
@@ -246,11 +246,16 @@ def run_cython_kernel_multi_stream(
         tensor_b = tensor_b.T
     tensor_c = torch.randn(M, N, dtype=out_dtype).cuda()
 
-    num_streams = 4
-    for _ in range(num_streams):
-        stream = torch.cuda.Stream()
+    streams = [torch.cuda.Stream() for _ in range(4)]
+    for stream in streams:
         with torch.cuda.stream(stream):
             matmul_kernel(tensor_a, tensor_b, tensor_c)
+
+    # The kernel launch is asynchronous with respect to the host. Wait for all
+    # side streams to finish before the test releases their tensors or the next
+    # test allocates new buffers on the default stream.
+    for stream in streams:
+        stream.synchronize()
 
 
 def test_cython_kernel_multi_stream():


### PR DESCRIPTION
## Problem
The MACA fusedmoe test is still marked `xfail`, even though it now passes on the current `dev` baseline. That stale marker turns a normal success into an `XPASS` and makes the MACA test suite harder to read.

While validating this cleanup on the upstream self-hosted MACA runner, the CI also exposed an unrelated instability in `testing/python/jit/test_tilelang_jit_gemm_cython.py`: the multi-stream coverage launched work on auxiliary streams but did not wait for those streams to finish before the following dynamic-shape test reused GPU state.

## What this PR changes
- removes the obsolete `xfail` marker from `examples/maca/fusedmoe/test_example_fusedmoe.py`
- synchronizes the auxiliary streams at the end of `run_cython_kernel_multi_stream()` in `testing/python/jit/test_tilelang_jit_gemm_cython.py`

## Solution
The fusedmoe change lets the test report its true outcome again.

The Cython test change keeps the existing multi-stream coverage, but makes the helper wait for the side streams it launches. This is the minimal fix: the kernel launches remain asynchronous, yet the test no longer leaves in-flight work behind for the next case.

## Alternatives considered
One option was to keep the stale `xfail` until a broader cleanup pass. That would have preserved misleading test output for no technical benefit.

Another option was to retry CI and treat the Cython failure as an unrelated flake. That would have left a real ordering bug in the test helper, and the same runner could fail again on the next PR.

A cleaner review boundary would be to submit the JIT test fix separately. I did not do that here because the failure blocked validation of this PR on the upstream MACA runner and the fix is small, local, and directly tied to getting this branch green.

## Verification
- `python -m pytest -q -rX examples/maca/fusedmoe/test_example_fusedmoe.py` on `origin/dev` -> `1 xpassed`
- `python -m pytest -q examples/maca/fusedmoe/test_example_fusedmoe.py` on this branch -> `1 passed`
- `pre-commit run --files examples/maca/fusedmoe/test_example_fusedmoe.py`
- `pre-commit run --files testing/python/jit/test_tilelang_jit_gemm_cython.py`
- exercised the branch version of `testing/python/jit/test_tilelang_jit_gemm_cython.py` against the built `dev` environment, including the CI order `test_cython_kernel_multi_stream()` -> `test_cython_dynamic_shape()`
- repeated `test_cython_kernel_multi_stream()` -> `test_cython_dynamic_shape()` 20 times without reproducing the MACA mismatch
