### PR TITLE
[MetaxGPU] Add MetaX backend support for shuffle synchronization primitives

### DIFF
--- a/src/target/codegen_maca.cc
+++ b/src/target/codegen_maca.cc
@@ -321,7 +321,7 @@ std::string CodeGenTileLangMACA::Finish() {
   decl_stream << "#include <tl_templates/maca/reduce.h>\n";
   decl_stream << "#include <tl_templates/maca/threadblock_swizzle.h>\n";
   decl_stream << "#include <tl_templates/maca/atomic.h>\n";
-  // decl_stream << "#include <tl_templates/maca/debug.h>\n";
+  decl_stream << "#include <tl_templates/maca/debug.h>\n";
   //  decl_stream << "#ifdef ENABLE_BF16\n";
   //  decl_stream << "#include <tl_templates/maca/maca_bf16_fallbacks.cuh>\n";
   //  decl_stream << "#endif\n";
@@ -2276,6 +2276,30 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
     enable_sparse_gemm_ = true;
     this->PrintCallExtern(GetType(tvm::ffi::GetRef<PrimExpr>(op)),
                           op_instance->value, op->args, true, os);
+  } else if (op->op.same_as(tl::shfl_sync())) {
+    ICHECK_EQ(op->args.size(), 4U)
+        << "tl.shfl_sync expects <mask, value, src_lane, width>.";
+    os << "__shfl_sync(" << PrintExpr(op->args[0]) << ", "
+       << PrintExpr(op->args[1]) << ", " << PrintExpr(op->args[2]) << ", "
+       << PrintExpr(op->args[3]) << ")";
+  } else if (op->op.same_as(tl::shfl_xor_sync())) {
+    ICHECK_EQ(op->args.size(), 4U)
+        << "tl.shfl_xor_sync expects <mask, value, lane_mask, width>.";
+    os << "__shfl_xor_sync(" << PrintExpr(op->args[0]) << ", "
+       << PrintExpr(op->args[1]) << ", " << PrintExpr(op->args[2]) << ", "
+       << PrintExpr(op->args[3]) << ")";
+  } else if (op->op.same_as(tl::shfl_down_sync())) {
+    ICHECK_EQ(op->args.size(), 4U)
+        << "tl.shfl_down_sync expects <mask, value, delta, width>.";
+    os << "__shfl_down_sync(" << PrintExpr(op->args[0]) << ", "
+       << PrintExpr(op->args[1]) << ", " << PrintExpr(op->args[2]) << ", "
+       << PrintExpr(op->args[3]) << ")";
+  } else if (op->op.same_as(tl::shfl_up_sync())) {
+    ICHECK_EQ(op->args.size(), 4U)
+        << "tl.shfl_up_sync expects <mask, value, delta, width>.";
+    os << "__shfl_up_sync(" << PrintExpr(op->args[0]) << ", "
+       << PrintExpr(op->args[1]) << ", " << PrintExpr(op->args[2]) << ", "
+       << PrintExpr(op->args[3]) << ")";
   } else if (op->op.same_as(Op::Get("tir.exp"))) {
     MACAMath math_func;
     std::string func_name = math_func(op->dtype, "exp");

--- a/src/tl_templates/maca/debug.h
+++ b/src/tl_templates/maca/debug.h
@@ -195,3 +195,10 @@ __device__ void debug_print_buffer_value<fp8_e4_t>(const char *msg,
 //          msg, blockIdx.x, blockIdx.y, blockIdx.z, threadIdx.x, threadIdx.y,
 //          threadIdx.z, buf_name, index, (float)var);
 // }
+
+TL_DEVICE void device_assert_with_msg(bool cond, const char *msg) {
+  if (!cond) {
+    printf("Device assert failed: %s\n", msg);
+    assert(0);
+  }
+}

--- a/testing/maca/language/test_tilelang_language_warp_sync.py
+++ b/testing/maca/language/test_tilelang_language_warp_sync.py
@@ -38,24 +38,97 @@ def test_warp_sync():
 def kernel_with_shfl_sync():
     @T.prim_func
     def main(
-        A: T.Tensor((32,), "int32"),
+        A: T.Tensor((64,), "int32"),
     ):
-        with T.Kernel(1, threads=32):
+        with T.Kernel(1, threads=64):
             tx = T.get_thread_binding()
             val = tx * 10
-            broadcast = T.shfl_sync(0xFFFFFFFF, val, 31)
+            broadcast = T.shfl_sync(val, 31, mask=0xFFFFFFFF)
             A[tx] = broadcast
 
     return main
 
 
-@tilelang.testing.requires_cuda
 def test_shfl_sync():
-    a = torch.empty((32), device="cuda", dtype=torch.int32)
+    a = torch.empty((64), device="cuda", dtype=torch.int32)
     kernel = kernel_with_shfl_sync()
     assert "__shfl_sync" in kernel.get_kernel_source()
     kernel(a)
     assert torch.all(a == 310)
+
+
+@tilelang.jit
+def kernel_with_shfl_up():
+    @T.prim_func
+    def main(
+        A: T.Tensor((64,), "int32"),
+    ):
+        with T.Kernel(1, threads=64):
+            tx = T.get_thread_binding()
+            val = tx
+            res = T.shfl_up(val, 1, mask=0xFFFFFFFF)
+            A[tx] = res
+
+    return main
+
+
+def test_shfl_up():
+    a = torch.empty((64), device="cuda", dtype=torch.int32)
+    kernel = kernel_with_shfl_up()
+    assert "__shfl_up" in kernel.get_kernel_source()
+    kernel(a)
+    assert a[0] == 0
+    for i in range(1, 64):
+        assert a[i] == i - 1
+
+
+@tilelang.jit
+def kernel_with_shfl_down():
+    @T.prim_func
+    def main(
+        A: T.Tensor((64,), "int32"),
+    ):
+        with T.Kernel(1, threads=64):
+            tx = T.get_thread_binding()
+            val = tx
+            res = T.shfl_down(val, 1, mask=0xFFFFFFFF)
+            A[tx] = res
+
+    return main
+
+
+def test_shfl_down():
+    a = torch.empty((64), device="cuda", dtype=torch.int32)
+    kernel = kernel_with_shfl_down()
+    assert "__shfl_down" in kernel.get_kernel_source()
+    kernel(a)
+    assert a[63] == 63
+    for i in range(63):
+        assert a[i] == i + 1
+
+
+@tilelang.jit
+def kernel_with_shfl_xor():
+    @T.prim_func
+    def main(
+        A: T.Tensor((64,), "int32"),
+    ):
+        with T.Kernel(1, threads=64):
+            tx = T.get_thread_binding()
+            val = tx
+            res = T.shfl_xor(val, 1, mask=0xFFFFFFFF)
+            A[tx] = res
+
+    return main
+
+
+def test_shfl_xor():
+    a = torch.empty((64), device="cuda", dtype=torch.int32)
+    kernel = kernel_with_shfl_xor()
+    assert "__shfl_xor" in kernel.get_kernel_source()
+    kernel(a)
+    for i in range(64):
+        assert a[i] == i ^ 1
 
 
 if __name__ == "__main__":

--- a/tilelang/language/builtin.py
+++ b/tilelang/language/builtin.py
@@ -6,13 +6,14 @@ from tilelang._typing import BufferLikeType, BufferLikeTypeTuple, BarrierType, D
 from tilelang import tvm as tvm
 from tilelang.language import ptx_arrive_barrier, evaluate
 from tilelang.language.kernel import get_thread_bindings, get_block_extents
-from tilelang.utils.target import check_hip_availability
+from tilelang.utils.target import check_hip_availability, check_maca_availability
 from tvm import DataType, tir
 from tvm.runtime import convert
 from tvm.tir import PrimExpr, Var, Call, BufferLoad, BufferRegion
 from tilelang.utils.language import retrieve_ptr
 
 _IS_HIP_AVAILABLE = check_hip_availability()
+_IS_MACA_AVAILABLE = check_maca_availability()
 
 
 def _normalize_index_arg(value: int | PrimExpr | None) -> PrimExpr | None:
@@ -876,8 +877,12 @@ def barrier_arrive(mbarrier: BarrierType):
 
 # Full-warp mask as a proper uint32 TIR constant so the emitted C/C++ source
 # prints as `0xFFFFFFFFu` instead of `(int64_t)4294967295` after TIR widening.
-_FULL_WARP_MASK = tir.const(0xFFFFFFFF, "uint32")
-_DEFAULT_SHFL_WIDTH = 32
+if _IS_MACA_AVAILABLE:
+    _FULL_WARP_MASK = tir.const(0xFFFFFFFF, "uint64")
+    _DEFAULT_SHFL_WIDTH = 64
+else:
+    _DEFAULT_SHFL_WIDTH = 32
+    _FULL_WARP_MASK = tir.const(0xFFFFFFFF, "uint32")
 
 
 def _as_uint32_mask(mask: int | PrimExpr) -> PrimExpr:
@@ -891,6 +896,17 @@ def _as_uint32_mask(mask: int | PrimExpr) -> PrimExpr:
     return mask
 
 
+def _as_uint64_mask(mask: int | PrimExpr) -> PrimExpr:
+    """Normalize a warp lane mask to a uint64 TIR expression.
+
+    Python literals (e.g. ``0xFFFFFFFF``) would otherwise be widened to int64
+    by TIR and printed as ``(int64_t)4294967295`` in the generated source.
+    """
+    if isinstance(mask, int):
+        return tir.const(mask, "uint64")
+    return mask
+
+
 def shfl_xor(
     value: int | PrimExpr | tir.Call,
     delta: int | PrimExpr | tir.Call,
@@ -900,6 +916,8 @@ def shfl_xor(
     """XOR-swap ``value`` across lanes (``__shfl_xor_sync`` on CUDA,
     ``__shfl_xor`` on HIP — mask ignored on HIP).
     """
+    if _IS_MACA_AVAILABLE:
+        return tir.call_intrin(value.dtype, tir.op.Op.get("tl.shfl_xor_sync"), _as_uint64_mask(mask), value, delta, width)
     return tir.call_intrin(value.dtype, tir.op.Op.get("tl.shfl_xor_sync"), _as_uint32_mask(mask), value, delta, width)
 
 
@@ -912,6 +930,8 @@ def shfl_down(
     """Shift ``value`` down by ``delta`` lanes (``__shfl_down_sync`` on CUDA,
     ``__shfl_down`` on HIP).
     """
+    if _IS_MACA_AVAILABLE:
+        return tir.call_intrin(value.dtype, tir.op.Op.get("tl.shfl_down_sync"), _as_uint64_mask(mask), value, delta, width)
     return tir.call_intrin(value.dtype, tir.op.Op.get("tl.shfl_down_sync"), _as_uint32_mask(mask), value, delta, width)
 
 
@@ -924,6 +944,8 @@ def shfl_up(
     """Shift ``value`` up by ``delta`` lanes (``__shfl_up_sync`` on CUDA,
     ``__shfl_up`` on HIP).
     """
+    if _IS_MACA_AVAILABLE:
+        return tir.call_intrin(value.dtype, tir.op.Op.get("tl.shfl_up_sync"), _as_uint64_mask(mask), value, delta, width)
     return tir.call_intrin(value.dtype, tir.op.Op.get("tl.shfl_up_sync"), _as_uint32_mask(mask), value, delta, width)
 
 
@@ -954,6 +976,8 @@ def shfl_sync(
     ``width`` lanes (``__shfl_sync`` on CUDA, ``__shfl`` on HIP — mask ignored
     on HIP).
     """
+    if _IS_MACA_AVAILABLE:
+        return tir.call_intrin(value.dtype, tir.op.Op.get("tl.shfl_sync"), _as_uint64_mask(mask), value, srcLane, width)
     return tir.call_intrin(value.dtype, tir.op.Op.get("tl.shfl_sync"), _as_uint32_mask(mask), value, srcLane, width)
 
 


### PR DESCRIPTION
- Feature: Implemented shfl_sync, shfl_down_sync, shfl_up_sync, and shfl_xor_sync in both codegen and the Python frontend to support the MetaX backend.

- Testing: Added unit tests to verify the correctness of these sync primitives.