### PR TITLE
[MetaXGPU] Fix AtomicAddx4 half/bfloat16 support

### DIFF
--- a/src/tl_templates/maca/atomic.h
+++ b/src/tl_templates/maca/atomic.h
@@ -179,19 +179,24 @@ TL_DEVICE void AtomicAddx2Ret(T1 *ref, T2 *val, T1 *ret, int memory_order = 0) {
 template <typename T1, typename T2>
 TL_DEVICE void AtomicAddx4(T1 *ref, T2 *val, int memory_order = 0) {
   (void)memory_order;
-  atomicAdd(reinterpret_cast<T1 *>(ref), static_cast<T1>(val[0]));
-  atomicAdd(reinterpret_cast<T1 *>(ref + 1), static_cast<T1>(val[1]));
-  atomicAdd(reinterpret_cast<T1 *>(ref + 2), static_cast<T1>(val[2]));
-  atomicAdd(reinterpret_cast<T1 *>(ref + 3), static_cast<T1>(val[3]));
+  using NT1 = typename normalize_atomic_type<T1>::type;
+  atomicAdd(reinterpret_cast<NT1 *>(ref), static_cast<NT1>(val[0]));
+  atomicAdd(reinterpret_cast<NT1 *>(ref + 1), static_cast<NT1>(val[1]));
+  atomicAdd(reinterpret_cast<NT1 *>(ref + 2), static_cast<NT1>(val[2]));
+  atomicAdd(reinterpret_cast<NT1 *>(ref + 3), static_cast<NT1>(val[3]));
 }
 
 template <typename T1, typename T2>
 TL_DEVICE void AtomicAddx4Ret(T1 *ref, T2 *val, T1 *ret, int memory_order = 0) {
   (void)memory_order;
-  ret[0] = atomicAdd(reinterpret_cast<T1 *>(ref), static_cast<T1>(val[0]));
-  ret[1] = atomicAdd(reinterpret_cast<T1 *>(ref + 1), static_cast<T1>(val[1]));
-  ret[2] = atomicAdd(reinterpret_cast<T1 *>(ref + 2), static_cast<T1>(val[2]));
-  ret[3] = atomicAdd(reinterpret_cast<T1 *>(ref + 3), static_cast<T1>(val[3]));
+  using NT1 = typename normalize_atomic_type<T1>::type;
+  ret[0] = atomicAdd(reinterpret_cast<NT1 *>(ref), static_cast<NT1>(val[0]));
+  ret[1] =
+      atomicAdd(reinterpret_cast<NT1 *>(ref + 1), static_cast<NT1>(val[1]));
+  ret[2] =
+      atomicAdd(reinterpret_cast<NT1 *>(ref + 2), static_cast<NT1>(val[2]));
+  ret[3] =
+      atomicAdd(reinterpret_cast<NT1 *>(ref + 3), static_cast<NT1>(val[3]));
 }
 
 // For vectorized AtomicAdd, we maintain two versions of interfaces:

--- a/testing/maca/language/test_tilelang_language_atomic.py
+++ b/testing/maca/language/test_tilelang_language_atomic.py
@@ -139,9 +139,9 @@ def run_atomic_different_memory_orders(M, N, block_M, block_N, dtype=T.float32):
 
 
 @tilelang.jit
-def atomic_addx4_program(M, N, block_M, block_N):
+def atomic_addx4_program(M, N, block_M, block_N, dtype=T.float32):
     @T.prim_func
-    def atomic_addx4(A: T.Tensor((M, N), T.float32), B: T.Tensor((M, N), T.float32)):
+    def atomic_addx4(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
         with T.Kernel(T.ceildiv(M, block_M), T.ceildiv(N, block_N), threads=32) as (bx, by):
             for i, j in T.Parallel(block_M, block_N // 4):
                 idx_i = bx * block_M + i
@@ -151,12 +151,12 @@ def atomic_addx4_program(M, N, block_M, block_N):
     return atomic_addx4
 
 
-def run_atomic_addx4(M, N, block_M, block_N):
-    kernel = atomic_addx4_program(M, N, block_M, block_N)
+def run_atomic_addx4(M, N, block_M, block_N, dtype=T.float32):
+    kernel = atomic_addx4_program(M, N, block_M, block_N, dtype=dtype)
     import torch
 
-    A = torch.randn(M, N, dtype=torch.float32).cuda()
-    B = torch.zeros(M, N, dtype=torch.float32).cuda()
+    A = torch.randn(M, N, dtype=getattr(torch, dtype)).cuda()
+    B = torch.zeros(M, N, dtype=getattr(torch, dtype)).cuda()
     ref_B = B.clone()
 
     for i in range(M):
@@ -295,9 +295,13 @@ def test_atomic_different_memory_orders():
     run_atomic_different_memory_orders(32, 32, 8, 8, dtype=T.bfloat16)
 
 
-# TODO: atomic_addx4 currently not support half
-def test_atomic_addx4():
-    run_atomic_addx4(16, 64, 4, 4)
+def test_atomic_addx4_float():
+    run_atomic_addx4(16, 64, 4, 4, dtype=T.float32)
+
+
+@tilelang.testing.requires_cuda
+def test_atomic_addx4_half():
+    run_atomic_addx4(16, 64, 4, 4, dtype=T.float16)
 
 
 def test_atomic_return_prev():


### PR DESCRIPTION
- maca/atomic.h: Add normalize_atomic_type for AtomicAddx4/AtomicAddx4Ret to correctly cast half_t/bfloat16_t to native half/maca_bfloat16 before calling atomicAdd.

- test_tilelang_language_atomic.py: Remove TODO, add dtype parameter to atomic_addx4 tests, and add test_atomic_addx4_half.