### PR TITLE
[MetaXGPU] enable the atomicAdd function to support the int64_t type

### DIFF
--- a/src/tl_templates/maca/atomic.h
+++ b/src/tl_templates/maca/atomic.h
@@ -7,6 +7,10 @@
 #include <mctlass/numeric_types.h>
 #include <type_traits>
 
+using half_t = __half;
+
+using bfloat16_t = maca_bfloat16;
+
 #define TL_DEVICE __forceinline__ __device__
 #define TL_NOT_IMPLEMENTED()                                                   \
   do {                                                                         \

--- a/src/tl_templates/maca/common.h
+++ b/src/tl_templates/maca/common.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "atomic.h"
 #include <common/maca_bfloat16.h>
 #include <common/maca_fp16.h>
 #include <cute/arch/mma.hpp>
@@ -242,8 +243,9 @@ TL_DEVICE unsigned __pack_maca_bfloat162(const bfloat16_t x,
 
 template <typename T1, typename T2>
 TL_DEVICE void AtomicAdd(T1 *address, T2 val, int memory_order = 0) {
+  using NT1 = typename normalize_atomic_type<T1>::type;
   (void)memory_order;
-  atomicAdd(reinterpret_cast<T1 *>(address), static_cast<T1>(val));
+  atomicAdd(reinterpret_cast<NT1 *>(address), static_cast<NT1>(val));
 }
 
 template <typename T> TL_DEVICE void AtomicAdd(_Float16 *address, T val) {


### PR DESCRIPTION
When the type of the atomicAdd parameter is not predefined, it needs to be converted uniformly.