### PR TITLE
[MetaxGPU][TileOps]clear stale async errors before kernel launch to avoid false failure

### DIFF
--- a/src/target/maca_module.cc
+++ b/src/target/maca_module.cc
@@ -204,6 +204,8 @@ public:
         << ". A zero grid dimension is often caused by a dynamic shape"
         << " (e.g. num_tokens) being 0 at runtime.";
 
+    mcGetLastError();
+
     void *config[] = {MC_LAUNCH_PARAM_BUFFER_POINTER, packed_args,
                       MC_LAUNCH_PARAM_BUFFER_SIZE, &packed_nbytes,
                       MC_LAUNCH_PARAM_END};


### PR DESCRIPTION
Auto-tuning for 12 TileOps failing cases explored configurations that exceed device memory limits, causing runtime errors.

TileLang recently introduced async error checking, which surfaces these errors. However, stale errors from previous runs were not cleared, leading to false failures in subsequent executions.

This change clears pending async error states before LaunchKernel, preventing error leakage across runs.