### PR TITLE
[MetaxGPU][testing] fix the ldg&stg error in testing/maca/language dir

### DIFF
--- a/src/target/codegen_maca.cc
+++ b/src/target/codegen_maca.cc
@@ -317,7 +317,7 @@ std::string CodeGenTileLangMACA::Finish() {
     decl_stream << "#include <tl_templates/maca/gemm_sp.h>\n";
   }
   // TODO: Add implementation for maca target.
-  // decl_stream << "#include <tl_templates/maca/copy.h>\n";
+  decl_stream << "#include <tl_templates/maca/copy.h>\n";
   decl_stream << "#include <tl_templates/maca/reduce.h>\n";
   decl_stream << "#include <tl_templates/maca/intrin.h>\n";
   decl_stream << "#include <tl_templates/maca/atomic.h>\n";
@@ -1489,7 +1489,7 @@ std::string CodeGenTileLangMACA::GetVecLoad(DataType t,
       << "Unsupported vector load size: " << t.bits() * t.lanes();
   auto buffer_ref = this->GetBufferRef(t, buffer, base);
   std::ostringstream os;
-  os << "tl::ld_global_256(&(" << buffer_ref << "))";
+  os << "tl::load_global_256(&(" << buffer_ref << "))";
   return os.str();
 }
 
@@ -1513,7 +1513,7 @@ void CodeGenTileLangMACA::PrintVecStore(const BufferNode *buffer, DataType t,
       << "Unsupported vector load size: " << t.bits() * t.lanes();
   auto buffer_ref = this->GetBufferRef(t, buffer, base);
   this->PrintIndent();
-  this->stream << "tl::st_global_256(&(" << buffer_ref << "), " << value
+  this->stream << "tl::store_global_256(&(" << buffer_ref << "), " << value
                << ");\n";
 }
 
@@ -2459,6 +2459,154 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
     std::string func_name = math_func(op->dtype, "fdiv", rounding_mode);
     os << func_name << "(" << PrintExpr(op->args[0]) << ", "
        << PrintExpr(op->args[1]) << ")";
+  } else if (op->op.same_as(tl::__ldg())) {
+    // Explicit read-only cached load. Preferred form: __ldg(BufferLoad(...)).
+    const BufferLoadNode *bl = nullptr;
+    if (!op->args.empty()) {
+      bl = op->args[0].as<BufferLoadNode>();
+    }
+    if (bl == nullptr) {
+      LOG(FATAL) << "T.__ldg expects a BufferLoad as the first argument.";
+    }
+    const BufferNode *buffer = bl->buffer.get();
+    ICHECK_EQ(bl->indices.size(), 1)
+        << "T.__ldg currently supports flattened 1D buffer accesses.";
+    PrimExpr base = bl->indices[0];
+    // Emit __ldg(&buffer_ref)
+    auto buffer_ref = this->GetBufferRef(op->dtype, buffer, base);
+    os << "__ldg(&(" << buffer_ref << "))";
+  } else if (op->op.same_as(tl::ldg32())) {
+    // Explicit 32-bit global memory load: load_global_32(ptr) or
+    // load_global_32_conditional(ptr, pred)
+    ICHECK(!op->args.empty()) << "T.ldg32 expects a pointer argument.";
+    if (op->args.size() > 1) {
+      os << "tl::load_global_32_conditional(";
+      this->PrintExpr(op->args[0], os);
+      os << ", ";
+      this->PrintExpr(op->args[1], os);
+    } else {
+      os << "tl::load_global_32(";
+      this->PrintExpr(op->args[0], os);
+    }
+    os << ")";
+  } else if (op->op.same_as(tl::ldg64())) {
+    // Explicit 64-bit global memory load: load_global_64(ptr) or
+    // load_global_64_conditional(ptr, pred)
+    ICHECK(!op->args.empty()) << "T.ldg64 expects a pointer argument.";
+    if (op->args.size() > 1) {
+      os << "tl::load_global_64_conditional(";
+      this->PrintExpr(op->args[0], os);
+      os << ", ";
+      this->PrintExpr(op->args[1], os);
+    } else {
+      os << "tl::load_global_64(";
+      this->PrintExpr(op->args[0], os);
+    }
+    os << ")";
+  } else if (op->op.same_as(tl::ldg128())) {
+    // Explicit 128-bit global memory load: load_global_128(ptr) or
+    // load_global_128_conditional(ptr, pred)
+    ICHECK(!op->args.empty()) << "T.ldg128 expects a pointer argument.";
+    if (op->args.size() > 1) {
+      os << "tl::load_global_128_conditional(";
+      this->PrintExpr(op->args[0], os);
+      os << ", ";
+      this->PrintExpr(op->args[1], os);
+    } else {
+      os << "tl::load_global_128(";
+      this->PrintExpr(op->args[0], os);
+    }
+    os << ")";
+  } else if (op->op.same_as(tl::ldg256())) {
+    // Explicit 256-bit global memory load: load_global_256(ptr) or
+    // load_global_256_conditional(ptr, pred)
+    ICHECK(!op->args.empty()) << "T.ldg256 expects a pointer argument.";
+    if (op->args.size() > 1) {
+      os << "tl::load_global_256_conditional(";
+      this->PrintExpr(op->args[0], os);
+      os << ", ";
+      this->PrintExpr(op->args[1], os);
+    } else {
+      os << "tl::load_global_256(";
+      this->PrintExpr(op->args[0], os);
+    }
+    os << ")";
+  } else if (op->op.same_as(tl::stg32())) {
+    // Explicit 32-bit global memory store: store_global_32(ptr, value) or
+    // store_global_32_conditional(ptr, value, pred)
+    ICHECK(op->args.size() >= 2)
+        << "T.stg32 expects pointer and value arguments.";
+    if (op->args.size() > 2) {
+      os << "tl::store_global_32_conditional(";
+      this->PrintExpr(op->args[0], os);
+      os << ", ";
+      this->PrintExpr(op->args[1], os);
+      os << ", ";
+      this->PrintExpr(op->args[2], os);
+    } else {
+      os << "tl::store_global_32(";
+      this->PrintExpr(op->args[0], os);
+      os << ", ";
+      this->PrintExpr(op->args[1], os);
+    }
+    os << ")";
+  } else if (op->op.same_as(tl::stg64())) {
+    // Explicit 64-bit global memory store: store_global_64(ptr, value) or
+    // store_global_64_conditional(ptr, value, pred)
+    ICHECK(op->args.size() >= 2)
+        << "T.stg64 expects pointer and value arguments.";
+    if (op->args.size() > 2) {
+      os << "tl::store_global_64_conditional(";
+      this->PrintExpr(op->args[0], os);
+      os << ", ";
+      this->PrintExpr(op->args[1], os);
+      os << ", ";
+      this->PrintExpr(op->args[2], os);
+    } else {
+      os << "tl::store_global_64(";
+      this->PrintExpr(op->args[0], os);
+      os << ", ";
+      this->PrintExpr(op->args[1], os);
+    }
+    os << ")";
+  } else if (op->op.same_as(tl::stg128())) {
+    // Explicit 128-bit global memory store: store_global_128(ptr, value) or
+    // store_global_128_conditional(ptr, value, pred)
+    ICHECK(op->args.size() >= 2)
+        << "T.stg128 expects pointer and value arguments.";
+    if (op->args.size() > 2) {
+      os << "tl::store_global_128_conditional(";
+      this->PrintExpr(op->args[0], os);
+      os << ", ";
+      this->PrintExpr(op->args[1], os);
+      os << ", ";
+      this->PrintExpr(op->args[2], os);
+    } else {
+      os << "tl::store_global_128(";
+      this->PrintExpr(op->args[0], os);
+      os << ", ";
+      this->PrintExpr(op->args[1], os);
+    }
+    os << ")";
+  } else if (op->op.same_as(tl::stg256())) {
+    // Explicit 256-bit global memory store: store_global_256(ptr, value) or
+    // store_global_256_conditional(ptr, value, pred)
+    ICHECK(op->args.size() >= 2)
+        << "T.stg256 expects pointer and value arguments.";
+    if (op->args.size() > 2) {
+      os << "tl::store_global_256_conditional(";
+      this->PrintExpr(op->args[0], os);
+      os << ", ";
+      this->PrintExpr(op->args[1], os);
+      os << ", ";
+      this->PrintExpr(op->args[2], os);
+    } else {
+      os << "tl::store_global_256(";
+      this->PrintExpr(op->args[0], os);
+      os << ", ";
+      this->PrintExpr(op->args[1], os);
+    }
+    os << ")";
   } else {
     CodeGenC::VisitExpr_(op, os);
   }

--- a/src/tl_templates/maca/copy.h
+++ b/src/tl_templates/maca/copy.h
@@ -1,0 +1,94 @@
+// Copyright (c) 2025 MetaX Integrated Circuits (Shanghai) Co., Ltd. All rights
+// reserved.
+#pragma once
+#include "common.h"
+namespace tl {
+// Global memory load intrinsics with explicit vector widths
+// MACA-compatible implementation using standard pointer casts
+// load_global_32: Load 32 bits, return uint32_t
+TL_DEVICE uint32_t load_global_32(const void *ptr) {
+  return *reinterpret_cast<const uint32_t *>(ptr);
+}
+// load_global_64: Load 64 bits, return uint2
+TL_DEVICE uint2 load_global_64(const void *ptr) {
+  return *reinterpret_cast<const uint2 *>(ptr);
+}
+// load_global_128: Load 128 bits, return uint4
+TL_DEVICE uint4 load_global_128(const void *ptr) {
+  return *reinterpret_cast<const uint4 *>(ptr);
+}
+// load_global_256: Load 256 bits, return ulonglong4
+TL_DEVICE ulonglong4 load_global_256(const void *ptr) {
+  return *reinterpret_cast<const ulonglong4 *>(ptr);
+}
+// Predicated (conditional) versions
+TL_DEVICE uint32_t load_global_32_conditional(const void *ptr, bool pred) {
+  if (pred) {
+    return *reinterpret_cast<const uint32_t *>(ptr);
+  }
+  return 0u;
+}
+TL_DEVICE uint2 load_global_64_conditional(const void *ptr, bool pred) {
+  if (pred) {
+    return *reinterpret_cast<const uint2 *>(ptr);
+  }
+  return make_uint2(0u, 0u);
+}
+TL_DEVICE uint4 load_global_128_conditional(const void *ptr, bool pred) {
+  if (pred) {
+    return *reinterpret_cast<const uint4 *>(ptr);
+  }
+  return make_uint4(0u, 0u, 0u, 0u);
+}
+TL_DEVICE ulonglong4 load_global_256_conditional(const void *ptr, bool pred) {
+  if (pred) {
+    return *reinterpret_cast<const ulonglong4 *>(ptr);
+  }
+  ulonglong4 zero;
+  zero.x = 0;
+  zero.y = 0;
+  zero.z = 0;
+  zero.w = 0;
+  return zero;
+}
+// Global memory store intrinsics with explicit vector widths
+// store_global_32: Store 32 bits
+TL_DEVICE void store_global_32(void *ptr, uint32_t value) {
+  *reinterpret_cast<uint32_t *>(ptr) = value;
+}
+// store_global_64: Store 64 bits
+TL_DEVICE void store_global_64(void *ptr, uint2 value) {
+  *reinterpret_cast<uint2 *>(ptr) = value;
+}
+// store_global_128: Store 128 bits
+TL_DEVICE void store_global_128(void *ptr, uint4 value) {
+  *reinterpret_cast<uint4 *>(ptr) = value;
+}
+// store_global_256: Store 256 bits
+TL_DEVICE void store_global_256(void *ptr, ulonglong4 value) {
+  *reinterpret_cast<ulonglong4 *>(ptr) = value;
+}
+// Predicated (conditional) versions
+TL_DEVICE void store_global_32_conditional(void *ptr, uint32_t value,
+                                           bool pred) {
+  if (pred) {
+    *reinterpret_cast<uint32_t *>(ptr) = value;
+  }
+}
+TL_DEVICE void store_global_64_conditional(void *ptr, uint2 value, bool pred) {
+  if (pred) {
+    *reinterpret_cast<uint2 *>(ptr) = value;
+  }
+}
+TL_DEVICE void store_global_128_conditional(void *ptr, uint4 value, bool pred) {
+  if (pred) {
+    *reinterpret_cast<uint4 *>(ptr) = value;
+  }
+}
+TL_DEVICE void store_global_256_conditional(void *ptr, ulonglong4 value,
+                                            bool pred) {
+  if (pred) {
+    *reinterpret_cast<ulonglong4 *>(ptr) = value;
+  }
+}
+} // namespace tl

--- a/testing/maca/language/test_tilelang_language_ldg.py
+++ b/testing/maca/language/test_tilelang_language_ldg.py
@@ -6,7 +6,6 @@ import tilelang.testing
 import torch
 
 
-@tilelang.testing.requires_cuda
 def test_ldg32_codegen():
     """Test that ldg32 generates tl::load_global_32 in CUDA source."""
 
@@ -34,7 +33,6 @@ def test_ldg32_codegen():
     torch.testing.assert_close(Y, Y_ref, atol=1e-5, rtol=1e-5)
 
 
-@tilelang.testing.requires_cuda
 def test_ldg64_codegen():
     """Test that ldg64 generates tl::load_global_64 in CUDA source."""
 
@@ -63,7 +61,6 @@ def test_ldg64_codegen():
     torch.testing.assert_close(Y, Y_ref, atol=1e-5, rtol=1e-5)
 
 
-@tilelang.testing.requires_cuda
 def test_ldg128_codegen():
     """Test that ldg128 generates tl::load_global_128 in CUDA source."""
 
@@ -92,8 +89,6 @@ def test_ldg128_codegen():
     torch.testing.assert_close(Y, Y_ref, atol=1e-5, rtol=1e-5)
 
 
-@tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_ge(10, 0)
 def test_ldg256_codegen():
     """Test that ldg256 generates tl::load_global_256 in CUDA source."""
 
@@ -122,7 +117,6 @@ def test_ldg256_codegen():
     torch.testing.assert_close(Y, Y_ref, atol=1e-5, rtol=1e-5)
 
 
-@tilelang.testing.requires_cuda
 def test_ldg32_predicated_codegen():
     """Test that ldg32 with predicate generates tl::load_global_32_conditional(ptr, pred) in CUDA source."""
 
@@ -157,7 +151,6 @@ def test_ldg32_predicated_codegen():
     torch.testing.assert_close(Y, Y_ref, atol=1e-5, rtol=1e-5)
 
 
-@tilelang.testing.requires_cuda
 def test_ldg64_predicated_codegen():
     """Test that ldg64 with predicate generates tl::load_global_64_conditional(ptr, pred) in CUDA source."""
 
@@ -193,7 +186,6 @@ def test_ldg64_predicated_codegen():
     torch.testing.assert_close(Y, Y_ref, atol=1e-5, rtol=1e-5)
 
 
-@tilelang.testing.requires_cuda
 def test_ldg128_predicated_codegen():
     """Test that ldg128 with predicate generates tl::load_global_128_conditional(ptr, pred) in CUDA source."""
 
@@ -229,8 +221,6 @@ def test_ldg128_predicated_codegen():
     torch.testing.assert_close(Y, Y_ref, atol=1e-5, rtol=1e-5)
 
 
-@tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_ge(10, 0)
 def test_ldg256_predicated_codegen():
     """Test that ldg256 with predicate generates tl::load_global_256_conditional(ptr, pred) in CUDA source."""
 

--- a/testing/maca/language/test_tilelang_language_stg.py
+++ b/testing/maca/language/test_tilelang_language_stg.py
@@ -6,7 +6,6 @@ import tilelang.testing
 import torch
 
 
-@tilelang.testing.requires_cuda
 def test_stg32_codegen():
     """Test that stg32 generates tl::store_global_32 in CUDA source."""
 
@@ -34,7 +33,6 @@ def test_stg32_codegen():
     torch.testing.assert_close(Y, X, atol=1e-5, rtol=1e-5)
 
 
-@tilelang.testing.requires_cuda
 def test_stg64_codegen():
     """Test that stg64 generates tl::store_global_64 in CUDA source."""
 
@@ -63,7 +61,6 @@ def test_stg64_codegen():
     torch.testing.assert_close(Y, X, atol=1e-5, rtol=1e-5)
 
 
-@tilelang.testing.requires_cuda
 def test_stg128_codegen():
     """Test that stg128 generates tl::store_global_128 in CUDA source."""
 
@@ -92,8 +89,6 @@ def test_stg128_codegen():
     torch.testing.assert_close(Y, X, atol=1e-5, rtol=1e-5)
 
 
-@tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_ge(10, 0)
 def test_stg256_codegen():
     """Test that stg256 generates tl::store_global_256 in CUDA source."""
 
@@ -122,7 +117,6 @@ def test_stg256_codegen():
     torch.testing.assert_close(Y, X, atol=1e-5, rtol=1e-5)
 
 
-@tilelang.testing.requires_cuda
 def test_stg32_predicated_codegen():
     """Test that stg32 with predicate generates tl::store_global_32_conditional(ptr, val, pred) in CUDA source."""
 
@@ -148,7 +142,6 @@ def test_stg32_predicated_codegen():
     assert "store_global_32" in src, "Expected store_global_32 call in generated CUDA source"
 
 
-@tilelang.testing.requires_cuda
 def test_stg64_predicated_codegen():
     """Test that stg64 with predicate generates tl::store_global_64_conditional(ptr, val, pred) in CUDA source."""
 
@@ -175,7 +168,6 @@ def test_stg64_predicated_codegen():
     assert "store_global_64" in src, "Expected store_global_64 call in generated CUDA source"
 
 
-@tilelang.testing.requires_cuda
 def test_stg128_predicated_codegen():
     """Test that stg128 with predicate generates tl::store_global_128_conditional(ptr, val, pred) in CUDA source."""
 
@@ -202,8 +194,6 @@ def test_stg128_predicated_codegen():
     assert "store_global_128" in src, "Expected store_global_128 call in generated CUDA source"
 
 
-@tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_ge(10, 0)
 def test_stg256_predicated_codegen():
     """Test that stg256 with predicate generates tl::store_global_256_conditional(ptr, val, pred) in CUDA source."""
 


### PR DESCRIPTION
I created a new file named copy.h to store the template functions related to ldg and stg. I then added the corresponding generation branches to the codegen_maca.cc file and corrected some incorrect references to ldg and stg in that file.