### PR TITLE
[MetaxGPU][testing] fix the error in test_tilelang_language_rand.py

### DIFF
--- a/src/target/codegen_maca.cc
+++ b/src/target/codegen_maca.cc
@@ -2091,6 +2091,12 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
     if (this->mcrand_random_generator_state_type ==
         "curandStatePhilox4_32_10_t") {
       this->mcrand_random_generator_state_type = "mcrandStatePhilox4_32_10_t";
+    } else if (this->mcrand_random_generator_state_type ==
+               "curandStateMRG32k3a_t") {
+      this->mcrand_random_generator_state_type = "mcrandStateMRG32k3a_t";
+    } else if (this->mcrand_random_generator_state_type ==
+               "curandStateXORWOW_t") {
+      this->mcrand_random_generator_state_type = "mcrandStateXORWOW_t";
     }
     this->PrintIndent();
     this->stream << this->mcrand_random_generator_state_type << " "

--- a/testing/maca/language/test_tilelang_language_rand.py
+++ b/testing/maca/language/test_tilelang_language_rand.py
@@ -6,7 +6,7 @@ import tilelang.testing
 
 
 @tilelang.jit
-def tilelang_rand_1d(M=1024, seed=42, generator="curandStatePhilox4_32_10_t"):
+def tilelang_rand_1d(M=1024, seed=42, generator="mcrandStatePhilox4_32_10_t"):
     num_per_thread = 128
     threads = 1
     blk_M = num_per_thread * threads
@@ -51,9 +51,8 @@ def tilelang_rand_1d(M=1024, seed=42, generator="curandStatePhilox4_32_10_t"):
     return rand_kernel
 
 
-@tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
-    "M, seed, generator", [(1024, 42, "curandStateMRG32k3a_t"), (512, 123, "curandStatePhilox4_32_10_t"), (128, 0, "curandStateXORWOW_t")]
+    "M, seed, generator", [(1024, 42, "mcrandStateMRG32k3a_t"), (512, 123, "mcrandStatePhilox4_32_10_t"), (128, 0, "mcrandStateXORWOW_t")]
 )
 def test_rand_1d(M, seed, generator):
     kernel = tilelang_rand_1d(M, seed, generator)

--- a/tilelang/language/random.py
+++ b/tilelang/language/random.py
@@ -23,7 +23,14 @@ def rng_init(seed, seq=None, off=0, generator="curandStatePhilox4_32_10_t") -> t
     state : PrimExpr
         The random number generator state handle.
     """
-    assert generator in ["curandStateMRG32k3a_t", "curandStatePhilox4_32_10_t", "curandStateXORWOW_t"]
+    assert generator in [
+        "curandStateMRG32k3a_t",
+        "curandStatePhilox4_32_10_t",
+        "curandStateXORWOW_t",
+        "mcrandStateMRG32k3a_t",
+        "mcrandStatePhilox4_32_10_t",
+        "mcrandStateXORWOW_t",
+    ]
     seed = tir.convert(seed)
     if seq is None:
         bx = T.get_block_binding()


### PR DESCRIPTION
I added a new branch for generating rand in the codegen_maca.cc file, then standardized the calls to rand-related functions across the frontend and backend, and added error-handling assertions to tilelang/language/random.py.