### PR TITLE
[MetaxGPU][testing] fix the error in language/atomic.py get_warp_info.py

### DIFF
--- a/src/target/codegen_maca.cc
+++ b/src/target/codegen_maca.cc
@@ -2207,6 +2207,18 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
       this->stream << ", " << PrintExpr(op->args[2]);
     }
     this->stream << ");\n";
+  } else if (op->op.same_as(tl::atomic_load_elem_op())) {
+    // atomic_load_elem_op(src_ptr, memory_order) -> returns loaded value
+    os << "AtomicLoad(" << PrintExpr(op->args[0]) << ", "
+       << PrintExpr(op->args[1]) << ")";
+  } else if (op->op.same_as(tl::atomic_store_elem_op())) {
+    // atomic_store_elem_op(dst_ptr, value, memory_order)
+    std::string dst_ptr = PrintExpr(op->args[0]);
+    std::string value = PrintExpr(op->args[1]);
+    std::string memory_order = PrintExpr(op->args[2]);
+    this->PrintIndent();
+    this->stream << "AtomicStore(" << dst_ptr << ", " << value << ", "
+                 << memory_order << ");\n";
   } else if (op->op.same_as(tl::atomic_max_elem_op())) {
     // atomic_max_elem_op(dst_ptr, src_value[, memory_order])
     std::string dst_ptr = PrintExpr(op->args[0]);

--- a/src/tl_templates/maca/atomic.h
+++ b/src/tl_templates/maca/atomic.h
@@ -91,25 +91,89 @@ TL_DEVICE T1 AtomicAddRet(T1 *address, T2 val,
 template <typename T1, typename T2>
 TL_DEVICE void AtomicMax(T1 *address, T2 val, int memory_order = 0) {
   (void)memory_order;
-  atomicMax(reinterpret_cast<T1 *>(address), static_cast<T1>(val));
+  using NT1 = typename normalize_atomic_type<T1>::type;
+  if constexpr (std::is_same_v<NT1, half> ||
+                std::is_same_v<NT1, maca_bfloat16>) {
+    // No native atomicMax for half/bf16 on MACA, use atomicCAS loop
+    unsigned short *address_as_ushort =
+        reinterpret_cast<unsigned short *>(address);
+    unsigned short val_as_ushort = *reinterpret_cast<unsigned short *>(&val);
+    unsigned short old_val_ushort = *address_as_ushort;
+    while (val > *reinterpret_cast<T1 *>(&old_val_ushort)) {
+      unsigned short assumed = old_val_ushort;
+      old_val_ushort = atomicCAS(address_as_ushort, assumed, val_as_ushort);
+      if (assumed == old_val_ushort)
+        break;
+    }
+  } else {
+    atomicMax(reinterpret_cast<T1 *>(address), static_cast<T1>(val));
+  }
 }
 
 template <typename T1, typename T2>
 TL_DEVICE T1 AtomicMaxRet(T1 *address, T2 val, int memory_order = 0) {
   (void)memory_order;
-  return atomicMax(reinterpret_cast<T1 *>(address), static_cast<T1>(val));
+  using NT1 = typename normalize_atomic_type<T1>::type;
+  if constexpr (std::is_same_v<NT1, half> ||
+                std::is_same_v<NT1, maca_bfloat16>) {
+    unsigned short *address_as_ushort =
+        reinterpret_cast<unsigned short *>(address);
+    unsigned short val_as_ushort = *reinterpret_cast<unsigned short *>(&val);
+    unsigned short old_val_ushort = *address_as_ushort;
+    while (val > *reinterpret_cast<T1 *>(&old_val_ushort)) {
+      unsigned short assumed = old_val_ushort;
+      old_val_ushort = atomicCAS(address_as_ushort, assumed, val_as_ushort);
+      if (assumed == old_val_ushort)
+        break;
+    }
+    return static_cast<T1>(*reinterpret_cast<T1 *>(&old_val_ushort));
+  } else {
+    return atomicMax(reinterpret_cast<T1 *>(address), static_cast<T1>(val));
+  }
 }
 
 template <typename T1, typename T2>
 TL_DEVICE void AtomicMin(T1 *address, T2 val, int memory_order = 0) {
   (void)memory_order;
-  atomicMin(reinterpret_cast<T1 *>(address), static_cast<T1>(val));
+  using NT1 = typename normalize_atomic_type<T1>::type;
+  if constexpr (std::is_same_v<NT1, half> ||
+                std::is_same_v<NT1, maca_bfloat16>) {
+    // No native atomicMin for half/bf16 on MACA, use atomicCAS loop
+    unsigned short *address_as_ushort =
+        reinterpret_cast<unsigned short *>(address);
+    unsigned short val_as_ushort = *reinterpret_cast<unsigned short *>(&val);
+    unsigned short old_val_ushort = *address_as_ushort;
+    while (val < *reinterpret_cast<T1 *>(&old_val_ushort)) {
+      unsigned short assumed = old_val_ushort;
+      old_val_ushort = atomicCAS(address_as_ushort, assumed, val_as_ushort);
+      if (assumed == old_val_ushort)
+        break;
+    }
+  } else {
+    atomicMin(reinterpret_cast<T1 *>(address), static_cast<T1>(val));
+  }
 }
 
 template <typename T1, typename T2>
 TL_DEVICE T1 AtomicMinRet(T1 *address, T2 val, int memory_order = 0) {
   (void)memory_order;
-  return atomicMin(reinterpret_cast<T1 *>(address), static_cast<T1>(val));
+  using NT1 = typename normalize_atomic_type<T1>::type;
+  if constexpr (std::is_same_v<NT1, half> ||
+                std::is_same_v<NT1, maca_bfloat16>) {
+    unsigned short *address_as_ushort =
+        reinterpret_cast<unsigned short *>(address);
+    unsigned short val_as_ushort = *reinterpret_cast<unsigned short *>(&val);
+    unsigned short old_val_ushort = *address_as_ushort;
+    while (val < *reinterpret_cast<T1 *>(&old_val_ushort)) {
+      unsigned short assumed = old_val_ushort;
+      old_val_ushort = atomicCAS(address_as_ushort, assumed, val_as_ushort);
+      if (assumed == old_val_ushort)
+        break;
+    }
+    return static_cast<T1>(*reinterpret_cast<T1 *>(&old_val_ushort));
+  } else {
+    return atomicMin(reinterpret_cast<T1 *>(address), static_cast<T1>(val));
+  }
 }
 
 TL_DEVICE inline void AtomicMax(float *address, float val,
@@ -166,38 +230,6 @@ TL_DEVICE inline float AtomicMinRet(float *address, float val,
   return __int_as_float(old);
 }
 
-// add x2   x4
-template <typename T1, typename T2>
-TL_DEVICE void AtomicAddx2(T1 *ref, T2 *val, int memory_order = 0) {
-  (void)memory_order;
-  atomicAdd(reinterpret_cast<T1 *>(ref), static_cast<T1>(val[0]));
-  atomicAdd(reinterpret_cast<T1 *>(ref + 1), static_cast<T1>(val[1]));
-}
-
-template <typename T1, typename T2>
-TL_DEVICE void AtomicAddx2Ret(T1 *ref, T2 *val, T1 *ret, int memory_order = 0) {
-  (void)memory_order;
-  ret[0] = atomicAdd(reinterpret_cast<T1 *>(ref), static_cast<T1>(val[0]));
-  ret[1] = atomicAdd(reinterpret_cast<T1 *>(ref + 1), static_cast<T1>(val[1]));
-}
-template <typename T1, typename T2>
-TL_DEVICE void AtomicAddx4(T1 *ref, T2 *val, int memory_order = 0) {
-  (void)memory_order;
-  atomicAdd(reinterpret_cast<T1 *>(ref), static_cast<T1>(val[0]));
-  atomicAdd(reinterpret_cast<T1 *>(ref + 1), static_cast<T1>(val[1]));
-  atomicAdd(reinterpret_cast<T1 *>(ref + 2), static_cast<T1>(val[2]));
-  atomicAdd(reinterpret_cast<T1 *>(ref + 3), static_cast<T1>(val[3]));
-}
-
-template <typename T1, typename T2>
-TL_DEVICE void AtomicAddx4Ret(T1 *ref, T2 *val, T1 *ret, int memory_order = 0) {
-  (void)memory_order;
-  ret[0] = atomicAdd(reinterpret_cast<T1 *>(ref), static_cast<T1>(val[0]));
-  ret[1] = atomicAdd(reinterpret_cast<T1 *>(ref + 1), static_cast<T1>(val[1]));
-  ret[2] = atomicAdd(reinterpret_cast<T1 *>(ref + 2), static_cast<T1>(val[2]));
-  ret[3] = atomicAdd(reinterpret_cast<T1 *>(ref + 3), static_cast<T1>(val[3]));
-}
-
 // For vectorized AtomicAdd, we maintain two versions of interfaces:
 // 1. AtomicAddxN(dst_type* ref, src_type *val) // Pass pointer
 // 2. AtomicAddxN(dst_type* ref, src_type val) // Pass value
@@ -244,4 +276,73 @@ TL_DEVICE void AtomicAddx2(bfloat16_t *ref, ValType val,
   (void)memory_order;
   maca_bfloat162 add_val = ToBfloat162(val);
   atomicAdd(reinterpret_cast<maca_bfloat162 *>(ref), add_val);
+}
+
+// Float2/Float4 helpers for vectorized atomic add
+template <typename T> TL_DEVICE float2 ToFloat2(T *val) {
+  return *reinterpret_cast<const float2 *>(val);
+}
+
+TL_DEVICE float2 ToFloat2(float2 val) { return val; }
+template <typename T> TL_DEVICE float4 ToFloat4(T *val) {
+  return *reinterpret_cast<const float4 *>(val);
+}
+
+TL_DEVICE float4 ToFloat4(float4 val) { return val; }
+
+// Scalar fallback for float AtomicAddx2
+template <typename ValType>
+TL_DEVICE void AtomicAddx2(float *ref, ValType val, int memory_order = 0) {
+  (void)memory_order;
+  float2 add_val = ToFloat2(val);
+  atomicAdd(ref + 0, add_val.x);
+  atomicAdd(ref + 1, add_val.y);
+}
+
+template <typename ValType>
+TL_DEVICE float2 AtomicAddx2Ret(float *ref, ValType val, int memory_order = 0) {
+  (void)memory_order;
+  float2 add_val = ToFloat2(val);
+  float2 ret;
+  ret.x = atomicAdd(ref + 0, add_val.x);
+  ret.y = atomicAdd(ref + 1, add_val.y);
+  return ret;
+}
+
+// Scalar fallback for float AtomicAddx4
+template <typename dst_dtype, typename ValType>
+TL_DEVICE void AtomicAddx4(dst_dtype *ref, ValType val, int memory_order = 0) {
+  (void)memory_order;
+  float4 add_val = ToFloat4(val);
+  atomicAdd(ref + 0, add_val.x);
+  atomicAdd(ref + 1, add_val.y);
+  atomicAdd(ref + 2, add_val.z);
+  atomicAdd(ref + 3, add_val.w);
+}
+
+template <typename dst_dtype, typename ValType>
+TL_DEVICE float4 AtomicAddx4Ret(dst_dtype *ref, ValType val,
+                                int memory_order = 0) {
+  (void)memory_order;
+  float4 add_val = ToFloat4(val);
+  float4 ret;
+  ret.x = atomicAdd(ref + 0, add_val.x);
+  ret.y = atomicAdd(ref + 1, add_val.y);
+  ret.z = atomicAdd(ref + 2, add_val.z);
+  ret.w = atomicAdd(ref + 3, add_val.w);
+  return ret;
+}
+
+// AtomicLoad / AtomicStore
+template <typename T> TL_DEVICE T AtomicLoad(T *ref, int memory_order) {
+  (void)memory_order;
+  volatile T *vref = reinterpret_cast<volatile T *>(ref);
+  return *vref;
+}
+
+template <typename T1, typename T2>
+TL_DEVICE void AtomicStore(T1 *ref, T2 value, int memory_order) {
+  (void)memory_order;
+  volatile T1 *vref = reinterpret_cast<volatile T1 *>(ref);
+  *vref = static_cast<T1>(value);
 }

--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -514,7 +514,8 @@ private:
       if (dtype.is_float16() || dtype.is_bfloat16()) {
         vectorize_length = 2;
       } else if (dtype.is_float() && dtype.bits() == 32 &&
-                 TargetHasSMVersionGE(Target::Current(false), 90)) {
+                     TargetHasSMVersionGE(Target::Current(false), 90) ||
+                 TargetIsMaca(Target::Current(false))) {
         vectorize_length = 4;
       }
 

--- a/src/transform/vectorize_loop.cc
+++ b/src/transform/vectorize_loop.cc
@@ -180,7 +180,7 @@ inline int GetMaxAtomicVectorSize(DataType dtype, Target target) {
     return 2;
   }
   if (dtype.is_float() && dtype.bits() == 32 &&
-      TargetHasSMVersionGE(target, 90)) {
+      (TargetHasSMVersionGE(target, 90) || TargetIsMaca(target))) {
     return 4;
   }
   return 1;

--- a/testing/maca/language/test_tilelang_language_atomic.py
+++ b/testing/maca/language/test_tilelang_language_atomic.py
@@ -199,36 +199,6 @@ def run_atomic_return_prev(M, N, block_M, block_N, dtype=T.float32):
     torch.testing.assert_close(B, initial_B + A, atol=1e-3, rtol=1e-3)
 
 
-@tilelang.jit
-def tma_atomic_add_program(out, explicit_swizzle=False):
-    out: T.Tensor[(16, 16), T.float32]
-
-    with T.Kernel(
-        1,
-    ):
-        out_shared = T.alloc_shared((16, 16), dtype=T.float32)
-        if explicit_swizzle:
-            T.annotate_layout({out_shared: tilelang.layout.make_swizzled_layout(out_shared)})
-        T.fill(out_shared, 1)
-        for _ in range(16):
-            T.atomic_add(out, out_shared, use_tma=True)
-
-
-@tilelang.testing.requires_cuda
-def test_tma_atomic_add():
-    out = torch.zeros((16, 16), dtype=torch.float32, device="cuda")
-    tma_atomic_add_program(out)
-    torch.testing.assert_close(out, torch.ones((16, 16), dtype=torch.float32, device="cuda") * 16)
-
-    kernel = tma_atomic_add_program.compile(out=T.Tensor[(16, 16), T.float32])
-    assert "tma_store_add" in kernel.get_kernel_source()
-    assert "desc" in kernel.get_kernel_source()  # Ensure using cp.reduce.async.bulk.tensor
-
-    kernel_with_explicit_swizzle = tma_atomic_add_program.compile(out=T.Tensor[(16, 16), T.float32], explicit_swizzle=True)
-    # Ensure auto swizzled layout is applied
-    assert kernel.get_kernel_source() == kernel_with_explicit_swizzle.get_kernel_source()
-
-
 def run_atomic_add_auto_vectorized(K, M, N, block_M, block_N, dtype=T.float32):
     tilelang.disable_cache()
     kernel = atomic_add_program(K, M, N, block_M, block_N, dtype=dtype)
@@ -274,12 +244,10 @@ def run_atomic_add_complicated_parallel(K, M, N, block_M, block_N, dtype=T.float
     assert "AtomicAddx4" in kernel.get_kernel_source()
 
 
-@tilelang.testing.requires_cuda
 def test_atomic_memory_order():
     run_atomic_memory_order(4, 64, 64, 16, 16)
 
 
-@tilelang.testing.requires_cuda
 def test_atomic_addx2_half():
     run_atomic_addx2(32, 64, 8, 16, dtype=T.float16)
 
@@ -288,7 +256,6 @@ def test_atomic_addx2_float():
     run_atomic_addx2(32, 64, 8, 16, dtype=T.float32)
 
 
-@tilelang.testing.requires_cuda
 def test_atomic_different_memory_orders():
     run_atomic_different_memory_orders(32, 32, 8, 8, dtype=T.float32)
     run_atomic_different_memory_orders(32, 32, 8, 8, dtype=T.float16)
@@ -308,14 +275,10 @@ def test_atomic_add():
     run_atomic_add(8, 128, 128, 32, 32)
 
 
-@tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_atomic_add_auto_vectorized():
     run_atomic_add_auto_vectorized(8, 128, 128, 32, 32, dtype=T.float32)
 
 
-@tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_atomic_add_auto_vectorized_unit_test():
     run_atomic_add_auto_vectorized_unit_test(2, dtype=T.float32)
     run_atomic_add_auto_vectorized_unit_test(4, dtype=T.float32)
@@ -323,7 +286,6 @@ def test_atomic_add_auto_vectorized_unit_test():
     run_atomic_add_auto_vectorized_unit_test(2, dtype=T.bfloat16)
 
 
-@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_atomic_add_complicated_parallel():
     run_atomic_add_complicated_parallel(8, 128, 128, 32, 32, dtype=T.float32)
 
@@ -534,7 +496,6 @@ def test_atomic_min():
     run_atomic_min(4, 64, 64, 16, 16)
 
 
-@tilelang.testing.requires_cuda
 def test_atomic_load_store():
     run_atomic_load_store(64, 64, 16, 16)
 

--- a/testing/maca/language/test_tilelang_language_get_warp_info.py
+++ b/testing/maca/language/test_tilelang_language_get_warp_info.py
@@ -6,13 +6,14 @@ import torch
 from tilelang.utils.target import check_maca_availability
 
 _IS_MACA_AVAILABLE = check_maca_availability()
+_IS_MACA_AVAILABLE = check_maca_availability()
 _DEFAULT_WARPS_PER_GROUP = 4
 
 
 def _resolve_warp_size(warp_size: Optional[int]) -> int:
     if warp_size is not None:
         return int(warp_size)
-    return 64 if _IS_MACA_AVAILABLE else 32
+    return 64 if (_IS_MACA_AVAILABLE or _IS_MACA_AVAILABLE) else 32
 
 
 def _resolve_warps_per_group(warps_per_group: Optional[int]) -> int:


### PR DESCRIPTION
I adjusted the definitions of some template functions (related to add op) in the atomic.h file to avoid errors caused by multiple template matches, added new atomic_load and atomic_store template functions, and refined the max and min functions to operate based on their parameters. I then added a generation branch for AtomicLoad and AtomicStore in the codegen_maca.cc file.