### PR TITLE
fix(maca): adapt fp16 GEMM MMA test to MACA sm100 hardware limitation

### DIFF
--- a/testing/maca/kernel/test_tilelang_kernel_gemm_mma_intrinsic.py
+++ b/testing/maca/kernel/test_tilelang_kernel_gemm_mma_intrinsic.py
@@ -215,10 +215,18 @@ def assert_tl_matmul_correctness(M, N, K, in_dtype, out_dtype, accum_dtype):
     tilelang.testing.torch_assert_close(C, ref_c, rtol=1e-2, atol=1e-2)
 
 
-@tilelang.testing.pytest.mark.xfail
-def test_assert_tl_matmul():
-    assert_tl_matmul_correctness(128, 128, 128, T.float16, T.float16, T.float16)
+def test_assert_tl_matmul_fp16_fp16_fp32():
+    # Note: MACA __builtin_mxc_mma_16x16x16f16 requires float[4] accumulator.
+    # FP16 accumulation is not supported on MACA sm100, so we use fp32 accum.
+    assert_tl_matmul_correctness(128, 128, 128, T.float16, T.float16, T.float32)
+
+
+def test_assert_tl_matmul_fp16_fp32_fp32():
     assert_tl_matmul_correctness(128, 256, 256, T.float16, T.float32, T.float32)
+
+
+@tilelang.testing.pytest.mark.xfail
+def test_assert_tl_matmul_int8_int32_int32():
     assert_tl_matmul_correctness(128, 256, 256, T.int8, T.int32, T.int32)
 
 


### PR DESCRIPTION
MACA __builtin_mxc_mma_16x16x16f16 requires float[4] (fp32 vector) accumulator. FP16 accumulation is not supported on MACA sm100, unlike CUDA Hopper.

Changes:
- Split test_assert_tl_matmul into independent test functions
- Change fp16/fp16/fp16 case to fp16/fp16/fp32 (fp32 accum)
- Remove xfail from now-passing fp16 cases
- Keep xfail on int8 case (separate issue)

Fixes compile error: float16x4 cannot be used as accumulator for __builtin_mxc_mma_16x16x16f16.
close:https://github.com/tile-ai/tilelang-metax/issues/69