### PR TITLE
[MetaxGPU][testing] fix the error in kernel/with_stride.py

### DIFF
--- a/testing/maca/kernel/test_tilelang_kernel_gemm_with_stride.py
+++ b/testing/maca/kernel/test_tilelang_kernel_gemm_with_stride.py
@@ -54,7 +54,7 @@ def run_gemm_with_stride_ss(M: int, N: int, K: int, block_M: int, block_N: int, 
     jit_kernel = tilelang.compile(
         func,
         out_idx=[2],
-        target="cuda",
+        target="maca",
         pass_configs={
             tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
             tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
@@ -76,8 +76,6 @@ def run_gemm_with_stride_ss(M: int, N: int, K: int, block_M: int, block_N: int, 
     print("Kernel output matches PyTorch reference.")
 
 
-@tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_ge(7, 5)
 def test_tilelang_kernel_gemm_with_stride():
     run_gemm_with_stride_ss(128, 128, 64, 32, 32, 32)
 

--- a/tilelang/tileop/gemm/gemm_base.py
+++ b/tilelang/tileop/gemm/gemm_base.py
@@ -94,6 +94,15 @@ class GemmBase:
 
     @property
     def chunk(self) -> int:
+        """
+        Get the logical compute width for the GEMM instruction.
+        Prioritizes the actual sliced extent from ARegion over physical buffer size.
+        """
+        if self.ARegion is not None:
+            k_axis = -2 if self.trans_A else -1
+            return self.ARegion.region[k_axis].extent
+        if self.K is not None:
+            return self.K
         return self.A.shape[-2] if self.trans_A else self.A.shape[-1]
 
     @property


### PR DESCRIPTION
Modify the gemm_base.py file so that the chunk can dynamically determine the actual logical slice width based on the extent of ARegion, thereby avoiding the blind reading of the tensor's physical allocation size.