### PR TITLE
[MetaxGPU][testing] fix the int8 vec error in language_vectorize.py

### DIFF
--- a/src/backend/maca/codegen/codegen_maca.cc
+++ b/src/backend/maca/codegen/codegen_maca.cc
@@ -2724,32 +2724,34 @@ void CodeGenTileLangMACA::VisitExpr_(const BroadcastNode *op,
                                      std::ostream &os) { // NOLINT(*)
   int lanes = static_cast<int>(Downcast<IntImm>(op->lanes)->value);
   if ((op->dtype.is_int() || op->dtype.is_uint()) && op->dtype.bits() == 8) {
-    if (lanes == 4) {
-      // make_int8x4
-      const int64_t *p = as_const_int(op->value);
-      ICHECK(p);
-      int64_t v = *p & 0xFF;
-      v = (v << 24) | (v << 16) | (v << 8) | v;
-      if (op->dtype.is_uint()) {
-        os << "(uint)" << v;
-      } else {
-        os << "(int)" << v;
+    const int64_t *p = as_const_int(op->value);
+    if (p) {
+      if (lanes == 4) {
+        // make_int8x4
+        ICHECK(p);
+        int64_t v = *p & 0xFF;
+        v = (v << 24) | (v << 16) | (v << 8) | v;
+        if (op->dtype.is_uint()) {
+          os << "(uint)" << v;
+        } else {
+          os << "(int)" << v;
+        }
+        return;
+      } else if (lanes == 32) {
+        // make_int8x32
+        const int64_t *p = as_const_int(op->value);
+        ICHECK(p);
+        int64_t v = *p & 0xFF;
+        v = (v << 24) | (v << 16) | (v << 8) | v;
+        if (op->dtype.is_uint()) {
+          os << "make_ulonglong4(" << v << ", " << v << ", " << v << ", " << v
+             << ")";
+        } else {
+          os << "make_longlong4(" << v << ", " << v << ", " << v << ", " << v
+             << ")";
+        }
+        return;
       }
-      return;
-    } else if (lanes == 32) {
-      // make_int8x32
-      const int64_t *p = as_const_int(op->value);
-      ICHECK(p);
-      int64_t v = *p & 0xFF;
-      v = (v << 24) | (v << 16) | (v << 8) | v;
-      if (op->dtype.is_uint()) {
-        os << "make_ulonglong4(" << v << ", " << v << ", " << v << ", " << v
-           << ")";
-      } else {
-        os << "make_longlong4(" << v << ", " << v << ", " << v << ", " << v
-           << ")";
-      }
-      return;
     }
   }
 

--- a/src/target/codegen_maca.cc
+++ b/src/target/codegen_maca.cc
@@ -2957,32 +2957,34 @@ void CodeGenTileLangMACA::VisitExpr_(const BroadcastNode *op,
                                      std::ostream &os) { // NOLINT(*)
   int lanes = static_cast<int>(Downcast<IntImm>(op->lanes)->value);
   if ((op->dtype.is_int() || op->dtype.is_uint()) && op->dtype.bits() == 8) {
-    if (lanes == 4) {
-      // make_int8x4
-      const int64_t *p = as_const_int(op->value);
-      ICHECK(p);
-      int64_t v = *p & 0xFF;
-      v = (v << 24) | (v << 16) | (v << 8) | v;
-      if (op->dtype.is_uint()) {
-        os << "(uint)" << v;
-      } else {
-        os << "(int)" << v;
+    const int64_t *p = as_const_int(op->value);
+    if (p) {
+      if (lanes == 4) {
+        // make_int8x4
+        ICHECK(p);
+        int64_t v = *p & 0xFF;
+        v = (v << 24) | (v << 16) | (v << 8) | v;
+        if (op->dtype.is_uint()) {
+          os << "(uint)" << v;
+        } else {
+          os << "(int)" << v;
+        }
+        return;
+      } else if (lanes == 32) {
+        // make_int8x32
+        const int64_t *p = as_const_int(op->value);
+        ICHECK(p);
+        int64_t v = *p & 0xFF;
+        v = (v << 24) | (v << 16) | (v << 8) | v;
+        if (op->dtype.is_uint()) {
+          os << "make_ulonglong4(" << v << ", " << v << ", " << v << ", " << v
+             << ")";
+        } else {
+          os << "make_longlong4(" << v << ", " << v << ", " << v << ", " << v
+             << ")";
+        }
+        return;
       }
-      return;
-    } else if (lanes == 32) {
-      // make_int8x32
-      const int64_t *p = as_const_int(op->value);
-      ICHECK(p);
-      int64_t v = *p & 0xFF;
-      v = (v << 24) | (v << 16) | (v << 8) | v;
-      if (op->dtype.is_uint()) {
-        os << "make_ulonglong4(" << v << ", " << v << ", " << v << ", " << v
-           << ")";
-      } else {
-        os << "make_longlong4(" << v << ", " << v << ", " << v << ", " << v
-           << ")";
-      }
-      return;
     }
   }
 

--- a/src/target/codegen_maca.cc
+++ b/src/target/codegen_maca.cc
@@ -2957,34 +2957,32 @@ void CodeGenTileLangMACA::VisitExpr_(const BroadcastNode *op,
                                      std::ostream &os) { // NOLINT(*)
   int lanes = static_cast<int>(Downcast<IntImm>(op->lanes)->value);
   if ((op->dtype.is_int() || op->dtype.is_uint()) && op->dtype.bits() == 8) {
-    const int64_t *p = as_const_int(op->value);
-    if (p) {
-      if (lanes == 4) {
-        // make_int8x4
-        ICHECK(p);
-        int64_t v = *p & 0xFF;
-        v = (v << 24) | (v << 16) | (v << 8) | v;
-        if (op->dtype.is_uint()) {
-          os << "(uint)" << v;
-        } else {
-          os << "(int)" << v;
-        }
-        return;
-      } else if (lanes == 32) {
-        // make_int8x32
-        const int64_t *p = as_const_int(op->value);
-        ICHECK(p);
-        int64_t v = *p & 0xFF;
-        v = (v << 24) | (v << 16) | (v << 8) | v;
-        if (op->dtype.is_uint()) {
-          os << "make_ulonglong4(" << v << ", " << v << ", " << v << ", " << v
-             << ")";
-        } else {
-          os << "make_longlong4(" << v << ", " << v << ", " << v << ", " << v
-             << ")";
-        }
-        return;
+    if (lanes == 4) {
+      // make_int8x4
+      const int64_t *p = as_const_int(op->value);
+      ICHECK(p);
+      int64_t v = *p & 0xFF;
+      v = (v << 24) | (v << 16) | (v << 8) | v;
+      if (op->dtype.is_uint()) {
+        os << "(uint)" << v;
+      } else {
+        os << "(int)" << v;
       }
+      return;
+    } else if (lanes == 32) {
+      // make_int8x32
+      const int64_t *p = as_const_int(op->value);
+      ICHECK(p);
+      int64_t v = *p & 0xFF;
+      v = (v << 24) | (v << 16) | (v << 8) | v;
+      if (op->dtype.is_uint()) {
+        os << "make_ulonglong4(" << v << ", " << v << ", " << v << ", " << v
+           << ")";
+      } else {
+        os << "make_longlong4(" << v << ", " << v << ", " << v << ", " << v
+           << ")";
+      }
+      return;
     }
   }
 

--- a/src/tl_templates/maca/maca_fp8.h
+++ b/src/tl_templates/maca/maca_fp8.h
@@ -234,7 +234,48 @@ public:
 };
 
 struct fp8_e8_t {
-  unsigned char data;
+  using value_t = unsigned char;
+  value_t v;
+
+  TL_DEVICE constexpr fp8_e8_t() : v{} {}
+
+  // construct from underlying storage
+  TL_DEVICE explicit fp8_e8_t(value_t x) : v(x) {}
+
+  // allow construction from types that can initialize the storage (e.g. int)
+  template <class T,
+            std::enable_if_t<!std::is_same_v<std::decay_t<T>, fp8_e8_t> &&
+                                 std::is_constructible_v<value_t, T>,
+                             int> = 0>
+  TL_DEVICE explicit fp8_e8_t(T &&x)
+      : v(static_cast<value_t>(std::forward<T>(x))) {}
+
+  // assignment from underlying storage
+  TL_DEVICE fp8_e8_t &operator=(value_t x) {
+    v = x;
+    return *this;
+  }
+
+  // implicit cast back to underlying storage when needed
+  TL_DEVICE operator value_t() const { return v; }
+
+private:
+  template <class To, class = void>
+  struct is_static_castable : std::false_type {};
+  template <class To>
+  struct is_static_castable<
+      To, std::void_t<decltype(static_cast<To>(std::declval<value_t>()))>>
+      : std::true_type {};
+
+public:
+  template <class To,
+            std::enable_if_t<!std::is_same_v<std::decay_t<To>, value_t> &&
+                                 !std::is_same_v<std::decay_t<To>, fp8_e8_t> &&
+                                 is_static_castable<To>::value,
+                             int> = 0>
+  TL_DEVICE operator To() const {
+    return static_cast<To>(v);
+  }
 };
 
 struct __MACA_ALIGN__(2) fp8_e4_2_t {

--- a/testing/maca/language/test_tilelang_language_vectorize.py
+++ b/testing/maca/language/test_tilelang_language_vectorize.py
@@ -124,7 +124,6 @@ def vectorize_test_all_dtypes(dtype, vec_num):
     return main
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "dtype",
     [
@@ -154,7 +153,6 @@ def vectorize_broadcast_int8(vec_num):
             a[i] = b
 
 
-@tilelang.testing.pytest.mark.xfail
 @pytest.mark.parametrize("vec_num", [4, 32])
 def test_vectorize_broadcast_int8(vec_num):
     """Test broadcasting a non-constant int8 value to a vectorized store."""


### PR DESCRIPTION
Modify the codegen to route the runtime variables to the fallback branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of 8-bit integer broadcast operations and small-float (FP8) value conversions to prevent incorrect packing/expansion across lanes.

* **Tests**
  * Re-enabled previously expected-fail tests for vectorized/broadcast cases; these tests now run normally and validate the fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang-metax/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->