### PR TITLE
docs: refresh Maca installation instructions

### DIFF
--- a/docs/get_started/Installation_maca.md
+++ b/docs/get_started/Installation_maca.md
@@ -83,7 +83,7 @@ apt-get install -y cmake git
 **Python packages prerequisites**
 
 ``` bash
-pip install z3-solver cython psutil cloudpickle tqdm torch-c-dlpack-ext
+pip install z3-solver cython psutil cloudpickle tqdm
 ```
 
 > **Note**: Version of z3-solver should be >= 4.13.0, include and lib directories should be found at installation path.
@@ -93,7 +93,7 @@ pip install z3-solver cython psutil cloudpickle tqdm torch-c-dlpack-ext
 Clone the tilelang repository
 
 ``` bash
-git clone --recursive https://gitee.com/metax-maca/mcTileLang.git
+git clone --recursive https://github.com/ventijing/tilelang-metax.git
 ```
 
 Build with MACA enabled, git committer must be identified.

--- a/docs/get_started/Installation_maca.md
+++ b/docs/get_started/Installation_maca.md
@@ -83,7 +83,7 @@ apt-get install -y cmake git
 **Python packages prerequisites**
 
 ``` bash
-pip install z3-solver cython psutil cloudpickle tqdm
+pip install z3-solver cython psutil cloudpickle tqdm torch-c-dlpack-ext
 ```
 
 > **Note**: Version of z3-solver should be >= 4.13.0, include and lib directories should be found at installation path.

--- a/docs/get_started/Installation_maca.md
+++ b/docs/get_started/Installation_maca.md
@@ -118,7 +118,7 @@ cd 3rdparty/tvm/3rdparty/tvm-ffi && pip install . && cd -
 ``` bash
 export MACA_PATH=/opt/maca
 export LD_LIBRARY_PATH=${MACA_PATH}/lib:${MACA_PATH}/mxgpu_llvm/lib:$LD_LIBRARY_PATH
-export PYTH=${MACA_PATH}/mxgpu_llvm/bin:${PATH}
+export PATH=${MACA_PATH}/mxgpu_llvm/bin:${PATH}
 export PYTHONPATH=/path/to/tilelang-metax:$PYTHONPATH
 
 python -c "import tilelang; print(tilelang.__version__)"

--- a/docs/get_started/Installation_maca.md
+++ b/docs/get_started/Installation_maca.md
@@ -93,7 +93,7 @@ pip install z3-solver cython psutil cloudpickle tqdm
 Clone the tilelang repository
 
 ``` bash
-git clone --recursive https://github.com/ventijing/tilelang-metax.git
+git clone --recursive https://github.com/tile-ai/tilelang-metax.git
 ```
 
 Build with MACA enabled, git committer must be identified.

--- a/docs/get_started/Installation_maca.md
+++ b/docs/get_started/Installation_maca.md
@@ -72,7 +72,7 @@ Check out [Metax docker](https://sw-download.metax-tech.com/docker) and download
 ``` bash
 docker login --username=cr_temp_user --password=eyJpbnN0YW5jZUlkIjoiY3JpLXpxYTIzejI2YTU5M3R3M2QiLCJ0aW1lIjoiMTc3MDg5NTI0MzAwMCIsInR5cGUiOiJzdWIiLCJ1c2VySWQiOiIyMDcwOTQwMTA1NjYzNDE3OTIifQ:91ecedb8bd5c4af6858745f0329d069263e1bf82 cr.metax-tech.com && docker pull cr.metax-tech.com/public-library/maca-pytorch:3.3.0.4-torch2.6-py310-ubuntu24.04-amd64
 
-docker run -it --net=host --device=/dev/dri --device=/dev/mxcd --group-add video --name mctilelang cr.metax-tech.com/public-library/maca-pytorch:3.3.0.4-torch2.6-py310-ubuntu24.04-amd64 /bin/bash
+docker run -it --net=host --device=/dev/dri --device=/dev/mxcd --group-add video --name tilelang-metax cr.metax-tech.com/public-library/maca-pytorch:3.3.0.4-torch2.6-py310-ubuntu24.04-amd64 /bin/bash
 
 apt-get update
 apt-get install -y cmake git
@@ -102,7 +102,7 @@ Build with MACA enabled, git committer must be identified.
 git config --global user.email "you@example.com"
 git config --global user.name "Your Name"
 
-cd mcTileLang
+cd tilelang-metax
 USE_MACA=ON cmake -B build
 make -C build -j 32
 ```
@@ -119,9 +119,9 @@ cd 3rdparty/tvm/3rdparty/tvm-ffi && pip install . && cd -
 export MACA_PATH=/opt/maca
 export LD_LIBRARY_PATH=${MACA_PATH}/lib:${MACA_PATH}/mxgpu_llvm/lib:$LD_LIBRARY_PATH
 export PYTH=${MACA_PATH}/mxgpu_llvm/bin:${PATH}
-export PYTHONPATH=/path/to/mcTileLang:$PYTHONPATH
+export PYTHONPATH=/path/to/tilelang-metax:$PYTHONPATH
 
 python -c "import tilelang; print(tilelang.__version__)"
 
-python path/to/mcTileLang/examples/quickstart.py
+python path/to/tilelang-metax/examples/quickstart.py
 ```


### PR DESCRIPTION
use tilelang-metax GitHub URL; remove torch-c-dlpack-ext from pip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Mac installation guide: renamed example Docker container, switched source-build instructions to the new repository, clarified working-directory step, updated PATH and PYTHONPATH setup, and adjusted quickstart/example invocation paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang-metax/pull/84)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->