### PR TITLE
[MetaxGPU][testing] Fix the error in language/isfinite_codegen.py

### DIFF
--- a/src/backend/maca/codegen/intrin_rule_maca.cc
+++ b/src/backend/maca/codegen/intrin_rule_maca.cc
@@ -258,6 +258,10 @@ TVM_REGISTER_OP("tir.rsqrt")
     .set_attr<FLowerIntrinsic>("maca.FLowerIntrinsic",
                                DispatchPureExtern<MACAMath>);
 
+TVM_REGISTER_OP("tir.isfinite")
+    .set_attr<FLowerIntrinsic>("maca.FLowerIntrinsic",
+                               DispatchPureExtern<Direct, true>);
+
 // Register low-level builtin ops.
 // TODO(tvm-team): consider make MACA its own subfolder and create a file for
 // low-level builtins.

--- a/testing/maca/language/test_tilelang_language_isfinite_codegen.py
+++ b/testing/maca/language/test_tilelang_language_isfinite_codegen.py
@@ -18,7 +18,7 @@ def _get_isfinite_source() -> str:
             pred = T.isfinite(x[0])
             y[0] = T.if_then_else(pred, 1, 0)
 
-    artifact = tilelang.lower(main, target="cuda")
+    artifact = tilelang.lower(main, target="maca")
     return artifact.kernel_source
 
 
@@ -28,12 +28,11 @@ def _get_isfinite_expr(code: str) -> str:
         match = re.search(pattern, line)
         if match:
             return match.group(1)
-    raise AssertionError("Failed to find CUDA isfinite call in generated source")
+    raise AssertionError("Failed to find MACA isfinite call in generated source")
 
 
-@tilelang.testing.requires_cuda
-def test_isfinite_codegen_uses_cuda_intrinsic():
-    """Check T.isfinite lowers to CUDA's isfinite for float32."""
+def test_isfinite_codegen_uses_maca_intrinsic():
+    """Check T.isfinite lowers to MACA's isfinite for float32."""
     src = _get_isfinite_source()
     expr = _get_isfinite_expr(src)
 
@@ -44,7 +43,7 @@ def test_isfinite_codegen_uses_cuda_intrinsic():
 
     assert "isfinite(" in expr
     assert "fabsf(" not in expr
-    assert "CUDART_INF_F" not in expr
+    assert "MACART_INF_F" not in expr
     assert "!= x[0]" not in expr
     assert "x[0] != x[0]" not in expr
 


### PR DESCRIPTION
 Fix lowering and codegen for isfinite to fix the error in language/isfinite_codegen.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the isfinite mathematical function when compiling code for MACA hardware targets

* **Tests**
  * Updated code generation tests to fully validate MACA compilation and optimization of isfinite operations
  * Enhanced test suite with MACA-specific validation for correct intrinsic code generation
  * Replaced CUDA-focused testing infrastructure with MACA platform-specific verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang-metax/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->