### PR TITLE
[MetaxGPU][testing] Add display synchronization for multiple streams

### DIFF
--- a/testing/python/jit/test_tilelang_jit_gemm_cython.py
+++ b/testing/python/jit/test_tilelang_jit_gemm_cython.py
@@ -250,6 +250,7 @@ def run_cython_kernel_multi_stream(
         stream = torch.cuda.Stream()
         with torch.cuda.stream(stream):
             matmul_kernel(tensor_a, tensor_b, tensor_c)
+    torch.cuda.synchronize()
 
 
 def test_cython_kernel_multi_stream():
@@ -301,7 +302,6 @@ def run_cython_dynamic_shape(
     tilelang.testing.torch_assert_close(tensor_c, tensor_ref_c, atol=1e-2, rtol=1e-2, max_mismatched_ratio=0.05)
 
 
-@tilelang.testing.pytest.mark.xfail
 def test_cython_dynamic_shape():
     run_cython_dynamic_shape(T.dynamic("m"), 256, 192, False, False, T.float16, T.float16, T.float32, 128, 128, 32, 2)
     run_cython_dynamic_shape(T.dynamic("m"), T.dynamic("n"), T.dynamic("k"), False, False, T.float16, T.float16, T.float32, 128, 128, 32, 2)


### PR DESCRIPTION
Fixed an issue in test_tilelang_jit_gemm_cython.py that carried over from the previous phase by adding explicit synchronization for multi-threading.