### PR TITLE
[MetaxGPU][testing] shrink MACA regression tiles to fit 64KB shared m…

### DIFF
--- a/examples/maca/attention_sink/example_mha_sink_fwd_bhsd.py
+++ b/examples/maca/attention_sink/example_mha_sink_fwd_bhsd.py
@@ -260,9 +260,9 @@ def run_regression_perf(
     dtype: str = "float16",
 ):
     torch_dtype = {"float16": torch.float16, "bfloat16": torch.bfloat16}[dtype]
-    block_M = 128
-    block_N = 128
-    num_stages = 2
+    block_M = 64
+    block_N = 64
+    num_stages = 1
     threads = 256
     kernel = flashattn(
         batch, heads, seq_q, seq_kv, dim, window_size, block_M=block_M, block_N=block_N, num_stages=num_stages, threads=threads, dtype=dtype

--- a/examples/maca/flash_attention/example_gqa_bwd.py
+++ b/examples/maca/flash_attention/example_gqa_bwd.py
@@ -510,10 +510,10 @@ def run_regression_perf():
             D_HEAD_QK,
             D_HEAD_V,
             causal,
-            block_M=128,
+            block_M=32,
             block_N=32,
             threads=256,
-            num_stages=2,
+            num_stages=1,
             groups=groups,
         )
     dQ = torch.zeros_like(Q, dtype=torch.float32)

--- a/examples/maca/flash_attention/example_gqa_bwd.py
+++ b/examples/maca/flash_attention/example_gqa_bwd.py
@@ -510,9 +510,9 @@ def run_regression_perf():
             D_HEAD_QK,
             D_HEAD_V,
             causal,
-            block_M=32,
-            block_N=32,
-            threads=256,
+            block_M=64,
+            block_N=16,
+            threads=128,
             num_stages=1,
             groups=groups,
         )

--- a/examples/maca/flash_attention/example_gqa_bwd_tma_reduce_varlen.py
+++ b/examples/maca/flash_attention/example_gqa_bwd_tma_reduce_varlen.py
@@ -719,9 +719,9 @@ def run_regression_perf():
             D_HEAD_QK,
             D_HEAD_V,
             causal,
-            block_M=32,
-            block_N=32,
-            threads=256,
+            block_M=64,
+            block_N=16,
+            threads=128,
             num_stages=1,
             groups=groups,
         )

--- a/examples/maca/flash_attention/example_gqa_bwd_tma_reduce_varlen.py
+++ b/examples/maca/flash_attention/example_gqa_bwd_tma_reduce_varlen.py
@@ -719,10 +719,10 @@ def run_regression_perf():
             D_HEAD_QK,
             D_HEAD_V,
             causal,
-            block_M=128,
+            block_M=32,
             block_N=32,
             threads=256,
-            num_stages=2,
+            num_stages=1,
             groups=groups,
         )
     dQ = torch.zeros_like(Q, dtype=torch.float32)

--- a/examples/maca/flash_attention/example_gqa_fwd_bshd.py
+++ b/examples/maca/flash_attention/example_gqa_fwd_bshd.py
@@ -198,7 +198,7 @@ def main(
 def run_regression_perf(
     batch: int = 1, heads: int = 64, seq_len: int = 4096, dim: int = 128, is_causal: bool = False, groups: int = 16, tune: bool = False
 ):
-    kernel = flashattn(batch, heads, seq_len, dim, is_causal, groups=groups, block_M=64, block_N=64, num_stages=2, threads=128)
+    kernel = flashattn(batch, heads, seq_len, dim, is_causal, groups=groups, block_M=64, block_N=64, num_stages=1, threads=128)
     profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
     return profiler.do_bench(backend="cupti")
 

--- a/examples/maca/flash_attention/example_mha_fwd_bhsd.py
+++ b/examples/maca/flash_attention/example_mha_fwd_bhsd.py
@@ -164,7 +164,7 @@ def run_regression_perf(
     is_causal: bool = False,
     tune: bool = False,
 ):
-    kernel = flashattn(batch, heads, seq_q, seq_kv, dim, is_causal, block_M=128, block_N=128, num_stages=2, threads=256)
+    kernel = flashattn(batch, heads, seq_q, seq_kv, dim, is_causal, block_M=128, block_N=128, num_stages=1, threads=256)
     profiler = kernel.get_profiler()
     return profiler.do_bench(backend="cupti")
 

--- a/examples/maca/flash_attention/example_mha_fwd_bshd.py
+++ b/examples/maca/flash_attention/example_mha_fwd_bshd.py
@@ -145,7 +145,7 @@ def main(
 
 
 def run_regression_perf(batch: int = 8, heads: int = 32, seq_len: int = 4096, dim: int = 128, is_causal: bool = False):
-    kernel = flashattn(batch, heads, seq_len, dim, is_causal, block_M=128, block_N=128, num_stages=1, threads=128)
+    kernel = flashattn(batch, heads, seq_len, dim, is_causal, block_M=64, block_N=64, num_stages=0, threads=128)
     profiler = kernel.get_profiler()
     return profiler.do_bench(backend="cupti")
 

--- a/examples/maca/flash_attention/example_mha_fwd_varlen.py
+++ b/examples/maca/flash_attention/example_mha_fwd_varlen.py
@@ -259,7 +259,7 @@ def run_regression_perf(batch: int = 8, heads: int = 64, seq_len: int = 2048, di
     ) = generate_qkv(q, k, v, query_padding_mask, key_padding_mask, kvpacked=False)
     UQ = q_unpad.shape[0]
     UKV = k_unpad.shape[0]
-    kernel = flashattn(batch, UQ, UKV, heads, dim, causal, block_M=128, block_N=128, num_stages=2, threads=256)
+    kernel = flashattn(batch, UQ, UKV, heads, dim, causal, block_M=128, block_N=128, num_stages=1, threads=256)
 
     from tilelang.profiler import do_bench
 

--- a/examples/maca/flash_decoding/example_mha_inference.py
+++ b/examples/maca/flash_decoding/example_mha_inference.py
@@ -258,8 +258,8 @@ def main(BATCH=1, H=32, Q_CTX=128, KV_CTX=8192, D_HEAD=128, causal=False):
 
 
 def run_regression_perf(BATCH=1, H=32, Q_CTX=128, KV_CTX=8192, D_HEAD=128, causal=False):
-    BLOCK_M = 128
-    BLOCK_N = 64
+    BLOCK_M = 64
+    BLOCK_N = 32
     kernel = flashattn(BATCH, H, Q_CTX, KV_CTX, D_HEAD, causal, BLOCK_M, BLOCK_N)
     profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
     return profiler.do_bench(backend="cupti")

--- a/examples/maca/linear_attention/example_linear_attn_bwd.py
+++ b/examples/maca/linear_attention/example_linear_attn_bwd.py
@@ -23,8 +23,8 @@ def tl_fused_chunk_bwd_kernel(
         scale = DK**-0.5
     accum_dtype = T.float32
 
-    chunk_size = 64
-    BK = BV = 64  # Set to 128 can be faster, but has some numerical differences with FLA
+    chunk_size = 32
+    BK = BV = 32  # Set to 128 can be faster, but has some numerical differences with FLA
     assert S % chunk_size == 0 and DK % BK == 0 and DV % BV == 0
     NK = tilelang.cdiv(DK, BK)
     NV = tilelang.cdiv(DV, BV)
@@ -134,7 +134,7 @@ def ref_program(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, scale: Option
     q, k, v = q.float(), k.float(), v.float()
     if scale is None:
         scale = q.shape[-1] ** -0.5
-    chunk_size = 64
+    chunk_size = 32
     q = rearrange(q, "b (n c) h d -> b h n c d", c=chunk_size) * scale
     k = rearrange(k, "b (n c) h d -> b h n c d", c=chunk_size)
     v = rearrange(v, "b (n c) h d -> b h n c d", c=chunk_size)


### PR DESCRIPTION
Lower block_M/block_N, num_stages, and linear-attn chunk sizes in
run_regression_perf only so pr-regression examples launch on MACA;
does not change default kernel APIs used outside regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated performance benchmark example configurations for attention mechanisms, including Flash Attention (forward and backward passes), Attention Sink, Flash Decoding, and Linear Attention. Adjusted kernel launch parameters such as block sizes, thread counts, pipeline stages, and chunk granularity to optimize resource utilization and refine regression performance testing across multiple kernel variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang-metax/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->