### PR TITLE
enable maca mma can use tf32

### DIFF
--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -20,6 +20,7 @@ namespace tl {
 TVM_REGISTER_PASS_CONFIG_OPTION(kDebugMergeSharedMemoryAllocations, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableSafeMemoryLegalize, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableWarpSpecialized, Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION(kEnableTF32InsteadofF32, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableThreadStorageSync, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kConfigIndexBitwidth, Integer);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableTMALower, Bool);

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -89,6 +89,8 @@ static constexpr const char *kDisableSafeMemoryLegalize =
     "tl.disable_safe_memory_legalize";
 static constexpr const char *kDisableWarpSpecialized =
     "tl.disable_warp_specialized";
+static constexpr const char *kEnableTF32InsteadofF32 =
+    "tl.enable_tf32_insteadof_f32";
 static constexpr const char *kConfigIndexBitwidth = "tl.config_index_bitwidth";
 // Deprecated pass config, temporarily re-enabled. Prevents plain T.copy()
 // from auto-lowering to TMA store. Will be removed in v0.1.10.

--- a/src/target/codegen_maca.cc
+++ b/src/target/codegen_maca.cc
@@ -1927,19 +1927,19 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
                     *((({C_dtype}*){c_ref}) + {c_bias}));
     })";
     std::string mfma_buildin = "__builtin_mxc_mma_" + prefix;
-    std::string target_value =
-        Target()::Current()->GetAttr<String>("mcpu").value();
 
+    std::string target_value =
+        Target::Current()->GetAttr<String>("mcpu").value();
     if ((target_value == "xcore1600") || (target_value == "xcore1500")) {
       tvm::transform::PassContext ctx = tvm::transform::PassContext::Current();
       bool kEnableTF32InsteadofF32 =
           ctx->GetConfig(tvm::tl::kEnableTF32InsteadofF32, Bool(false))
               .value()
               ->value;
-      if ((A_type == "int8x4") || (!kEnableTF32InsteadofF32))) {
-          mfma_buildin = "tl::mxc_mma_" + prefix;
-          need_mma_instruction_h_ = true;
-        }
+      if ((A_dtype == "int8x4") || (!kEnableTF32InsteadofF32)) {
+        mfma_buildin = "tl::mxc_mma_" + prefix;
+        need_mma_instruction_h_ = true;
+      }
     }
 
     Replacer replacer;

--- a/src/target/codegen_maca.cc
+++ b/src/target/codegen_maca.cc
@@ -473,6 +473,20 @@ void CodeGenTileLangMACA::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
       os << GetTileLangFP6Type(t);
     }
     return;
+  } else if (t.is_tfloat32()) {
+    if (t.is_scalar()) {
+      os << "float";
+    } else if (lanes <= 4) {
+      os << "float" << lanes;
+    } else if (lanes <= 8) {
+      ICHECK_EQ(lanes % 2, 0)
+          << "only support even lane for tfloat32 type with lanes > 4";
+      os << "float" << lanes / 2;
+    } else {
+      fail = true;
+    }
+    if (!fail)
+      return;
   } else if (t.is_float4()) {
     enable_fp4_ = true;
     if (t.lanes() <= 64) {
@@ -1894,6 +1908,7 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
         {"float16x8", "float16x8"},
         {"bfloat16x4", "bfloat16x4_vec"},
         {"bfloat16x8", "bfloat16x8_vec"},
+        {"float32x2", "float32x2"},
         {"float32x4", "float32x4"},
         {"float8_e4m3fnuzx4", "int32x2"},
         {"float8_e4m3fnx4", "int32x2"},
@@ -1904,6 +1919,7 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
         {"float8_e5m2x4", "fp8_e5_4_t"},
         {"float8_e5m2x8", "int32x2"},
         {"float32x16", "float32x16"},
+        {"custom[tfloat32]x2", "float32x2"},
         {"float32x32", "float32x32"}};
     std::string call_mfma_code = R"({
       *((({C_dtype}*){c_ref}) + {c_bias}) = {mfma_buildin}(*((({A_dtype}*){a_ref}) + {a_bias}),
@@ -1911,6 +1927,21 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
                     *((({C_dtype}*){c_ref}) + {c_bias}));
     })";
     std::string mfma_buildin = "__builtin_mxc_mma_" + prefix;
+    std::string target_value =
+        Target()::Current()->GetAttr<String>("mcpu").value();
+
+    if ((target_value == "xcore1600") || (target_value == "xcore1500")) {
+      tvm::transform::PassContext ctx = tvm::transform::PassContext::Current();
+      bool kEnableTF32InsteadofF32 =
+          ctx->GetConfig(tvm::tl::kEnableTF32InsteadofF32, Bool(false))
+              .value()
+              ->value;
+      if ((A_type == "int8x4") || (!kEnableTF32InsteadofF32))) {
+          mfma_buildin = "tl::mxc_mma_" + prefix;
+          need_mma_instruction_h_ = true;
+        }
+    }
+
     Replacer replacer;
 
     replacer.register_rule("{mfma_buildin}", mfma_buildin);

--- a/src/tl_templates/maca/common.h
+++ b/src/tl_templates/maca/common.h
@@ -67,6 +67,8 @@ using float16x8 =
     __attribute__((__vector_size__(8 * sizeof(float16_t)))) float16_t;
 using float16x16 =
     __attribute__((__vector_size__(16 * sizeof(float16_t)))) float16_t;
+
+using float32x2 = __attribute__((__vector_size__(2 * sizeof(float)))) float;
 namespace platform {
 
 /// Numeric limits

--- a/src/tl_templates/maca/mma.h
+++ b/src/tl_templates/maca/mma.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "../common.h"
+
+namespace tl {
+
+TL_DEVICE float32x4 mxc_mma_16x16x4f32(float a, float b, float32x4 c) {
+  return __builtin_mxc_mma_16x16x8tf32({a, 0.0f}, {b, 0.0f}, c);
+}
+
+TL_DEVICE int32x4 mxc_mma_16x16x16i8(int a, int b, int32x4 c) {
+  return __builtin_mxc_mma_16x16x16i8({a, 0}, {b, 0}, c);
+}
+
+} // namespace tl

--- a/testing/maca/kernel/test_tilelang_kernel_gemm.py
+++ b/testing/maca/kernel/test_tilelang_kernel_gemm.py
@@ -153,7 +153,6 @@ def test_gemm_bf16bf16f32_nn():
     )
 
 
-@tilelang.testing.pytest.mark.xfail
 def test_gemm_f32f32f32_nn():
     run_gemm(
         512,
@@ -219,7 +218,6 @@ def test_gemm_f64f64f64_nt():
     run_gemm(512, 512, 512, False, True, T.float64, T.float64, T.float64, 64, 32, 16)
 
 
-@tilelang.testing.pytest.mark.xfail
 def test_gemm_f32f32f32_nt():
     run_gemm(
         512,
@@ -237,7 +235,6 @@ def test_gemm_f32f32f32_nt():
 
 
 # TODO(Gong): Meets precision issue on ROCm, disable for now
-@tilelang.testing.pytest.mark.xfail
 def test_gemm_f32f32f32_tn():
     run_gemm(
         512,

--- a/testing/maca/language/test_tilelang_language_ptr.py
+++ b/testing/maca/language/test_tilelang_language_ptr.py
@@ -79,7 +79,7 @@ def pointer_table_grouped_matmul_test(batch_sizes_list, N, K, block_M, block_N, 
         c_ptrs: T.Tensor([batch_count], T.ptr),
         batch_tile_offsets: T.Tensor([batch_count], T.int32),
     ):
-        with T.Kernel(total_m_blocks, T.ceildiv(N, block_N), threads=32) as (bx, by):
+        with T.Kernel(total_m_blocks, T.ceildiv(N, block_N), threads=64) as (bx, by):
             A_shared = T.alloc_shared((block_M, block_K), dtype)
             B_shared = T.alloc_shared((block_K, block_N), dtype)
             C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
@@ -227,7 +227,6 @@ def test_pointer_table_multi_copy():
     run_pointer_table_multi_copy(2, 64)
 
 
-@tilelang.testing.requires_cuda
 def test_pointer_table_grouped_matmul():
     run_pointer_table_grouped_matmul([8, 12, 17], 32, 32, 16, 16, 16)
 

--- a/tilelang/maca/intrinsics/layout/mma_layout.py
+++ b/tilelang/maca/intrinsics/layout/mma_layout.py
@@ -26,6 +26,30 @@ def thread_id_shared_access_64x1_to_4x16_layout_B(thread_id, local_id):
     return i, j
 
 
+def shared_16x8_to_local_64x2_layout_A(i, j):
+    thread_id = i + 16 * (j // 2)
+    local = j % 2
+    return thread_id, local
+
+
+def thread_id_shared_access_64x2_to_16x8_layout_A(thread_id, local_id):
+    i = thread_id % 16
+    j = (thread_id // 16) * 2 + local_id
+    return i, j
+
+
+def shared_8x16_to_local_64x2_layout_B(i, j):
+    thread_id = j + 16 * (i // 2)
+    local = i % 2
+    return thread_id, local
+
+
+def thread_id_shared_access_64x2_to_8x16_layout_B(thread_id, local_id):
+    i = (thread_id // 16) * 2 + local_id
+    j = thread_id % 16
+    return i, j
+
+
 def shared_16x16_to_local_64x4_layout_C(i, j):
     thread_id = j + (i // 4) * 16
     local = i % 4

--- a/tilelang/maca/intrinsics/macro/mma_macro_generator.py
+++ b/tilelang/maca/intrinsics/macro/mma_macro_generator.py
@@ -15,12 +15,16 @@ from tilelang.utils.language import get_buffer_region_from_load
 from tilelang.maca.intrinsics.layout.mma_layout import (
     shared_16x4_to_local_64x1_layout_A,
     shared_4x16_to_local_64x1_layout_B,
+    shared_16x8_to_local_64x2_layout_A,
+    shared_8x16_to_local_64x2_layout_B,
     shared_16x16_to_local_64x4_layout_A,
     shared_16x16_to_local_64x4_layout_B,
     shared_16x32_to_local_64x8_layout_A,
     shared_16x32_to_local_64x8_layout_B,
     thread_id_shared_access_64x1_to_16x4_layout_A,
     thread_id_shared_access_64x1_to_4x16_layout_B,
+    thread_id_shared_access_64x2_to_16x8_layout_A,
+    thread_id_shared_access_64x2_to_8x16_layout_B,
     thread_id_shared_access_64x4_to_16x16_layout_A,
     thread_id_shared_access_64x4_to_16x16_layout_B,
     thread_id_shared_access_64x8_to_16x32_layout_A,
@@ -89,6 +93,7 @@ class TensorCoreIntrinEmitter:
         self.warp_row_tiles = warp_row_tiles
         self.warp_col_tiles = warp_col_tiles
         self.chunk = chunk
+        self._initialize_whether_use_tf32()
         self._initialize_k_dim(a_dtype)
         self._initialize_abbrev(a_dtype, b_dtype, accum_dtype)
         self._initialize_local_size(self.M_DIM, self.N_DIM, self.k_dim, self.WARP_SIZE)
@@ -105,6 +110,11 @@ class TensorCoreIntrinEmitter:
         self.num_elems_per_byte = num_elems_per_byte
         self.thread_var = thread_var
 
+    def _initialize_whether_use_tf32(self):
+        pass_ctx = tvm.get_global_func("transform.GetCurrentPassContext")()
+        enable_tf32_insteadof_f32 = pass_ctx.config.get("tl.enable_tf32_insteadof_f32", False)
+        self.enable_tf32_insteadof_f32 = enable_tf32_insteadof_f32
+
     def _initialize_k_dim(self, a_dtype=T.float16):
         if isinstance(a_dtype, str):
             if a_dtype in ["float8_e4m3fn", "float8_e4m3fnuz", "float8_e5m2", "float8_e5m2fnuz"]:
@@ -113,7 +123,10 @@ class TensorCoreIntrinEmitter:
             a_dtype = DataType(a_dtype)
 
         if a_dtype.bits == 32:
-            self.k_dim = 4
+            if self.enable_tf32_insteadof_f32:
+                self.k_dim = 8
+            else:
+                self.k_dim = 4
         elif a_dtype.bits in {16, 8}:
             self.k_dim = 16
         else:
@@ -147,7 +160,7 @@ class TensorCoreIntrinEmitter:
         in_dtype_map = {
             "bfloat16": "bf16",
             "float16": "f16",
-            "float32": "f32",
+            "float32": "tf32" if self.enable_tf32_insteadof_f32 else "f32",
             "int8": "i8",
             "int32": "i32",
             "float8_e4m3": "f8",
@@ -167,6 +180,8 @@ class TensorCoreIntrinEmitter:
             self.mma_suffix = f"{M_DIM}x{N_DIM}x{k_dim}i8"
         elif in_dtype_abbrv == "bf16":
             self.mma_suffix = f"{M_DIM}x{N_DIM}x{k_dim}bf16"
+        elif in_dtype_abbrv == "tf32":
+            self.mma_suffix = f"{M_DIM}x{N_DIM}x{k_dim}tf32"
         else:
             self.mma_suffix = f"{M_DIM}x{N_DIM}x{k_dim}{in_dtype_abbrv}"
 
@@ -199,6 +214,16 @@ class TensorCoreIntrinEmitter:
                 index_map = shared_16x4_to_local_64x1_layout_A if transposed else shared_4x16_to_local_64x1_layout_B
                 reverse_index_map = (
                     thread_id_shared_access_64x1_to_16x4_layout_A if transposed else thread_id_shared_access_64x1_to_4x16_layout_B
+                )
+        elif k_dim == 8:
+            index_map = shared_8x16_to_local_64x2_layout_B if transposed else shared_16x8_to_local_64x2_layout_A
+            reverse_index_map = (
+                thread_id_shared_access_64x2_to_8x16_layout_B if transposed else thread_id_shared_access_64x2_to_16x8_layout_A
+            )
+            if is_b:
+                index_map = shared_16x8_to_local_64x2_layout_A if transposed else shared_8x16_to_local_64x2_layout_B
+                reverse_index_map = (
+                    thread_id_shared_access_64x2_to_16x8_layout_A if transposed else thread_id_shared_access_64x2_to_8x16_layout_B
                 )
         elif k_dim == 16:
             index_map = shared_16x16_to_local_64x4_layout_B if transposed else shared_16x16_to_local_64x4_layout_A
@@ -376,9 +401,9 @@ class TensorCoreIntrinEmitter:
         k_pack = self.k_pack
         mma_suffix = self.mma_suffix
         a_dtype, b_dtype, out_dtype = self.a_dtype, self.b_dtype, self.accum_dtype
-        compute_a_dtype = a_dtype if local_size_a == 1 else f"{a_dtype}x{local_size_a}"
-        compute_b_dtype = b_dtype if local_size_b == 1 else f"{b_dtype}x{local_size_b}"
-        compute_out_dtype = out_dtype if local_size_out == 1 else f"{out_dtype}x{local_size_out}"
+        compute_a_dtype = str(a_dtype) if local_size_a == 1 else f"{a_dtype}x{local_size_a}"
+        compute_b_dtype = str(b_dtype) if local_size_b == 1 else f"{b_dtype}x{local_size_b}"
+        compute_out_dtype = str(out_dtype) if local_size_out == 1 else f"{out_dtype}x{local_size_out}"
 
         a_is_fragment = is_fragment(A_local_buf)
         b_is_fragment = is_fragment(B_local_buf)
@@ -492,6 +517,9 @@ class TensorCoreIntrinEmitter:
         if k_dim == 4:
             transform_func_sr_a = shared_16x4_to_local_64x1_layout_A
             transform_func_sr_b = shared_16x4_to_local_64x1_layout_A
+        elif k_dim == 8:
+            transform_func_sr_a = shared_16x8_to_local_64x2_layout_A
+            transform_func_sr_b = shared_16x8_to_local_64x2_layout_A
         elif k_dim == 16:
             transform_func_sr_a = shared_16x16_to_local_64x4_layout_A
             transform_func_sr_b = shared_16x16_to_local_64x4_layout_A
@@ -599,7 +627,7 @@ class TensorCoreIntrinEmitter:
 
         shape = local_buf.shape
         inverse_mma_store_layout = self.get_store_index_map(inverse=True)
-        assert is_fragment(local_buf), "local_buf must be a fragment"
+        assert is_fragment(local_buf), f"local_buf {local_buf} must be a fragment"
         micro_size_x, micro_size_y = self.micro_size_x, self.micro_size_y
         local_size_out = self.local_size_out
         block_row_warps, block_col_warps = self.block_row_warps, self.block_col_warps
@@ -780,7 +808,6 @@ class TensorCorePreshuffleIntrinEmitter(TensorCoreIntrinEmitter):
                         )
                         A_local_buf[i * k_pack * local_size_a + local_id] = A_shared_buf[l, r, row, col]
             else:
-                print(self.a_preshuffle)
                 for i in T.serial(warp_rows):
                     for local_id in T.vectorized(k_pack * local_size_a):
                         row, col = T.meta_var(reverse_index_map(tx, local_id))

--- a/tilelang/maca/intrinsics/macro/mma_macro_generator.py
+++ b/tilelang/maca/intrinsics/macro/mma_macro_generator.py
@@ -527,7 +527,7 @@ class TensorCoreIntrinEmitter:
             transform_func_sr_a = shared_16x32_to_local_64x8_layout_A
             transform_func_sr_b = shared_16x32_to_local_64x8_layout_A
         else:
-            raise ValueError(f"k_dim must be 0 currently but got {k_dim}")
+            raise ValueError(f"Unsupported k_dim={k_dim}; expected one of 4, 8, 16, 32")
 
         is_sr_conditions = [False]
         is_sr_conditions.append(matrix_is_a and not transposed)

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -58,6 +58,9 @@ class PassConfigKey(str, Enum):
     TL_DISABLE_WARP_SPECIALIZED = "tl.disable_warp_specialized"
     """Disable warp specialization optimization. Default: False"""
 
+    TL_ENABLE_TF32_INSTEADOF_F32 = "tl.enable_tf32_insteadof_f32"
+    """enable tf32 be used instead of f32. Default: False"""
+
     TL_ENABLE_FAST_MATH = "tl.enable_fast_math"
     """
         Enable fast math optimization. Default: False

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -59,7 +59,7 @@ class PassConfigKey(str, Enum):
     """Disable warp specialization optimization. Default: False"""
 
     TL_ENABLE_TF32_INSTEADOF_F32 = "tl.enable_tf32_insteadof_f32"
-    """enable tf32 be used instead of f32. Default: False"""
+    """Enable using TF32 instead of F32. Default: False"""
 
     TL_ENABLE_FAST_MATH = "tl.enable_fast_math"
     """


### PR DESCRIPTION
- Used TF32 data type for MMA on MetaX.
- Removed tilelang.testing.pytest.mark.xfail from some test cases since they can run properly now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TensorFloat32 (TF32) support for MACA matrix operations as an alternative to standard float32 precision.
  * Introduced new MMA (Matrix Multiply Accumulate) intrinsic functions for optimized tensor computations.
  * Added shared-memory layout conversion helpers for improved matrix tiling on MACA devices.

* **Bug Fixes**
  * Float32 GEMM test cases now pass successfully without expected failure markers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang-metax/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->