### PR TITLE
[CI][MACA] Install patched tvm-ffi in perf regression bot workflow

### DIFF
--- a/.github/workflows/pr-regression-test-bot.yml
+++ b/.github/workflows/pr-regression-test-bot.yml
@@ -210,6 +210,9 @@ jobs:
             uv pip install -v --no-deps --python-version 3.10.0 flash_linear_attention==0.4.0+metax3.5.3.9torch2.8 -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
           fi
           uv pip install -v .
+          if [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
+            uv pip install -v 3rdparty/tvm/3rdparty/tvm-ffi
+          fi
 
       - name: Install dev branch (Baseline)
         run: |
@@ -229,6 +232,9 @@ jobs:
             uv pip install -v --no-deps --python-version 3.10.0 flash_linear_attention==0.4.0+metax3.5.3.9torch2.8 -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
           fi
           uv pip install -v .
+          if [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
+            uv pip install -v 3rdparty/tvm/3rdparty/tvm-ffi
+          fi
           rm -rf tilelang build
 
           uv venv --python "${{ matrix.python-version }}" test_regression


### PR DESCRIPTION
Install 3rdparty/tvm/3rdparty/tvm-ffi after tilelang in new/old venvs
so MACA regression gets kDLMACA and avoids DLDeviceType attribute errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI regression test workflow to conditionally install required dependencies based on toolkit availability, improving test environment setup consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->