### PR TITLE
[MetaxGPU][testing] Add missing double2 ->e8m0x2 conversion in fp8.h

### DIFF
--- a/src/tl_templates/maca/maca_fp8.h
+++ b/src/tl_templates/maca/maca_fp8.h
@@ -615,3 +615,80 @@ __tl_cvt_fp8x2_to_float2(const __maca_fp8x2_storage_t x,
   }
   return result;
 }
+
+// ==========================================================================
+// FP8 E8M0 Related Conversions
+// ==========================================================================
+
+// e8m0 -> float
+TL_DEVICE float __tl_cvt_e8m0_to_float(const unsigned char src) {
+  unsigned int bits = (static_cast<unsigned int>(src) << 23);
+  return *reinterpret_cast<float *>(&bits);
+}
+
+// e8m0 -> bfloat16
+TL_DEVICE bfloat16_t __tl_cvt_e8m0_to_bfloat16(const unsigned char src) {
+  return static_cast<bfloat16_t>(__tl_cvt_e8m0_to_float(src));
+}
+
+// e8m0x2 -> bfloat16x2
+TL_DEVICE __maca_bfloat162
+__tl_cvt_e8m0x2_to_bfloat162(const __maca_fp8x2_storage_t src) {
+  unsigned char lo = static_cast<unsigned char>(src & 0xFF);
+  unsigned char hi = static_cast<unsigned char>((src >> 8) & 0xFF);
+  float f_lo = __tl_cvt_e8m0_to_float(lo);
+  float f_hi = __tl_cvt_e8m0_to_float(hi);
+  return __floats2bfloat162_rn(f_lo, f_hi);
+}
+
+// float -> e8m0
+TL_DEVICE unsigned char __tl_cvt_float_to_e8m0(const float src) {
+  unsigned int bits = *reinterpret_cast<const unsigned int *>(&src);
+  unsigned int exponent = (bits >> 23) & 0xFF;
+  unsigned int mantissa = bits & 0x7FFFFF;
+  if (mantissa > 0 && exponent < 0xFF) {
+    exponent += 1;
+  }
+  return static_cast<unsigned char>(exponent);
+}
+
+// float2 -> e8m0x2
+TL_DEVICE __maca_fp8x2_storage_t __tl_cvt_float2_to_e8m0x2(const float2 src) {
+  unsigned char lo = __tl_cvt_float_to_e8m0(src.x);
+  unsigned char hi = __tl_cvt_float_to_e8m0(src.y);
+  return static_cast<__maca_fp8x2_storage_t>(lo) |
+         (static_cast<__maca_fp8x2_storage_t>(hi) << 8);
+}
+
+// double -> e8m0
+TL_DEVICE unsigned char __tl_cvt_double_to_e8m0(const double src) {
+  return __tl_cvt_float_to_e8m0(static_cast<float>(src));
+}
+
+// double2 -> e8m0x2
+TL_DEVICE __maca_fp8x2_storage_t __tl_cvt_double2_to_e8m0x2(const double2 src) {
+  unsigned char lo = __tl_cvt_double_to_e8m0(static_cast<float>(src.x));
+  unsigned char hi = __tl_cvt_double_to_e8m0(static_cast<float>(src.y));
+  return static_cast<__maca_fp8x2_storage_t>(lo) |
+         (static_cast<__maca_fp8x2_storage_t>(hi) << 8);
+}
+
+// bfloat16 -> e8m0
+TL_DEVICE unsigned char __tl_cvt_bfloat16_to_e8m0(const bfloat16_t src) {
+  return __tl_cvt_float_to_e8m0(static_cast<float>(src));
+}
+
+// bfloat162 -> e8m0x2
+TL_DEVICE __maca_fp8x2_storage_t
+__tl_cvt_bfloat162_to_e8m0x2(const __maca_bfloat162 src) {
+  const bfloat16_t *val_ptr = reinterpret_cast<const bfloat16_t *>(&src);
+
+  float low_f = static_cast<float>(val_ptr[0]);
+  float high_f = static_cast<float>(val_ptr[1]);
+
+  unsigned char lo = __tl_cvt_float_to_e8m0(low_f);
+  unsigned char hi = __tl_cvt_float_to_e8m0(high_f);
+
+  return static_cast<__maca_fp8x2_storage_t>(lo) |
+         (static_cast<__maca_fp8x2_storage_t>(hi) << 8);
+}

--- a/testing/python/language/test_tilelang_language_vectorized_cast.py
+++ b/testing/python/language/test_tilelang_language_vectorized_cast.py
@@ -78,7 +78,6 @@ def run_vectorized_cast(src_dtype: T.dtype, dst_dtype: T.dtype, check_str: str, 
     torch.testing.assert_close(A.to(dst_dtype.as_torch()), C)
 
 
-@tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
     "src_dtype, dst_dtype, check_str, lanes",
     [
@@ -96,16 +95,14 @@ def test_vectorized_cast(src_dtype, dst_dtype, check_str, lanes):
     run_vectorized_cast(src_dtype, dst_dtype, check_str, lanes)
 
 
-@tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_ge(8, 9)
 @pytest.mark.parametrize(
     "src_dtype, dst_dtype, check_str, lanes",
     [
         # FP8 <-> FP32
-        (T.float32, T.float8_e4m3fn, "__nv_cvt_float2_to_fp8x2", 2),
-        (T.float32, T.float8_e4m3fn, "__nv_cvt_float2_to_fp8x2", 4),
-        (T.float32, T.float8_e5m2, "__nv_cvt_float2_to_fp8x2", 2),
-        (T.float32, T.float8_e5m2, "__nv_cvt_float2_to_fp8x2", 4),
+        (T.float32, T.float8_e4m3fn, "__maca_cvt_float2_to_fp8x2", 2),
+        (T.float32, T.float8_e4m3fn, "__maca_cvt_float2_to_fp8x2", 4),
+        (T.float32, T.float8_e5m2, "__maca_cvt_float2_to_fp8x2", 2),
+        (T.float32, T.float8_e5m2, "__maca_cvt_float2_to_fp8x2", 4),
         (T.float8_e4m3fn, T.float32, "__tl_cvt_fp8x2_to_float2", 2),
         (T.float8_e4m3fn, T.float32, "__tl_cvt_fp8x2_to_float2", 4),
         (T.float8_e5m2, T.float32, "__tl_cvt_fp8x2_to_float2", 2),
@@ -123,8 +120,6 @@ def test_vectorized_cast_fp8(src_dtype, dst_dtype, check_str, lanes):
     run_vectorized_cast(src_dtype, dst_dtype, check_str, lanes)
 
 
-@tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_ge(10, 0)
 @pytest.mark.parametrize(
     "src_dtype, dst_dtype, check_str, lanes",
     [

--- a/testing/python/language/test_tilelang_language_vectorized_cast.py
+++ b/testing/python/language/test_tilelang_language_vectorized_cast.py
@@ -78,6 +78,7 @@ def run_vectorized_cast(src_dtype: T.dtype, dst_dtype: T.dtype, check_str: str, 
     torch.testing.assert_close(A.to(dst_dtype.as_torch()), C)
 
 
+@tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
     "src_dtype, dst_dtype, check_str, lanes",
     [
@@ -95,6 +96,7 @@ def test_vectorized_cast(src_dtype, dst_dtype, check_str, lanes):
     run_vectorized_cast(src_dtype, dst_dtype, check_str, lanes)
 
 
+@tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
     "src_dtype, dst_dtype, check_str, lanes",
     [
@@ -120,6 +122,7 @@ def test_vectorized_cast_fp8(src_dtype, dst_dtype, check_str, lanes):
     run_vectorized_cast(src_dtype, dst_dtype, check_str, lanes)
 
 
+@tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
     "src_dtype, dst_dtype, check_str, lanes",
     [


### PR DESCRIPTION
Add complete bidirectional conversion kernels between FP8-E8M0 and float/bfloat16 scalar/vector types for MACA device. These TL_DEVICE helper routines support quantization/dequantization used in low-precision grouped-GEMM and MoE inference, covering scalar, dual-element vector and double-precision fallback paths with proper exponent rounding rules to guarantee numerical correctness during type cast.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FP8 E8M0 conversion support for float, bfloat16, and double, including packed/vectorized x2 variants.

* **Bug Fixes**
  * FP8 vectorized-cast test updated to run as a normal pass/fail test (no longer marked expected-to-fail).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->