### PR TITLE
[MetaxGPU][testing] correct FP64 MMA store layout to fix the test pre…

### DIFF
--- a/src/maca/codegen/codegen_maca.cc
+++ b/src/maca/codegen/codegen_maca.cc
@@ -1811,6 +1811,7 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
         {"float16", "half"},
         {"float32", "float"},
         {"float64", "double"},
+        {"float64x4", "float64x4"},
         {"float16x4", "float16x4"},
         {"float16x8", "float16x8"},
         {"bfloat16x4", "bfloat16x4_vec"},

--- a/testing/python/kernel/test_tilelang_kernel_gemm.py
+++ b/testing/python/kernel/test_tilelang_kernel_gemm.py
@@ -1,9 +1,6 @@
 from tilelang import tvm as tvm
 import tilelang.testing
 import tilelang.language as T
-import torch
-
-torch.backends.cuda.matmul.allow_tf32 = False
 
 
 def matmul(
@@ -106,6 +103,7 @@ def run_gemm(
     profiler.assert_allclose(ref_program, atol=1e-2, rtol=1e-2)
 
 
+@tilelang.testing.requires_cuda
 def test_gemm_f16f16f16_nn():
     run_gemm(
         512,
@@ -155,6 +153,7 @@ def test_gemm_bf16bf16f32_nn():
     )
 
 
+@tilelang.testing.requires_cuda_or_cdna
 def test_gemm_f32f32f32_nn():
     run_gemm(
         512,
@@ -171,6 +170,7 @@ def test_gemm_f32f32f32_nn():
     )
 
 
+@tilelang.testing.requires_cuda
 def test_gemm_f16f16f16_tn():
     run_gemm(
         512,
@@ -188,6 +188,7 @@ def test_gemm_f16f16f16_tn():
     )
 
 
+@tilelang.testing.requires_cuda
 def test_gemm_f16f16f16_nt():
     run_gemm(
         512,
@@ -205,18 +206,22 @@ def test_gemm_f16f16f16_nt():
     )
 
 
+@tilelang.testing.requires_cuda_or_cdna
 def test_gemm_i8i8i32_nt():
     run_gemm(512, 1024, 768, False, True, T.int8, T.int8, T.int32, 128, 128, 64)
 
 
+@tilelang.testing.requires_cuda_or_cdna
 def test_gemm_i8i8i32_tn():
     run_gemm(512, 1024, 768, True, False, T.int8, T.int8, T.int32, 128, 128, 64)
 
 
+@tilelang.testing.requires_cuda
 def test_gemm_f64f64f64_nt():
     run_gemm(512, 512, 512, False, True, T.float64, T.float64, T.float64, 64, 32, 16)
 
 
+@tilelang.testing.requires_cuda_or_cdna
 def test_gemm_f32f32f32_nt():
     run_gemm(
         512,
@@ -233,6 +238,8 @@ def test_gemm_f32f32f32_nt():
     )
 
 
+# TODO(Gong): Meets precision issue on ROCm, disable for now
+@tilelang.testing.requires_cuda
 def test_gemm_f32f32f32_tn():
     run_gemm(
         512,
@@ -249,6 +256,7 @@ def test_gemm_f32f32f32_tn():
     )
 
 
+@tilelang.testing.requires_cuda
 def test_pad_aligned_f16f16f16_nn():
     run_gemm(
         512 - 8,
@@ -266,6 +274,7 @@ def test_pad_aligned_f16f16f16_nn():
     )
 
 
+@tilelang.testing.requires_cuda
 def test_pad_f16f16f16_nn():
     run_gemm(
         512 - 9,
@@ -517,6 +526,7 @@ def run_gemm_rs(
     profiler.assert_allclose(ref_program, atol=1e-2, rtol=1e-2)
 
 
+# Register source A operand GMMAs must have K-major A layout.
 def test_gemm_f16f16f16_rs():
     run_gemm_rs(
         512,

--- a/testing/python/kernel/test_tilelang_kernel_gemm.py
+++ b/testing/python/kernel/test_tilelang_kernel_gemm.py
@@ -1,6 +1,9 @@
 from tilelang import tvm as tvm
 import tilelang.testing
 import tilelang.language as T
+import torch
+
+torch.backends.cuda.matmul.allow_tf32 = False
 
 
 def matmul(
@@ -103,7 +106,6 @@ def run_gemm(
     profiler.assert_allclose(ref_program, atol=1e-2, rtol=1e-2)
 
 
-@tilelang.testing.requires_cuda
 def test_gemm_f16f16f16_nn():
     run_gemm(
         512,
@@ -153,7 +155,6 @@ def test_gemm_bf16bf16f32_nn():
     )
 
 
-@tilelang.testing.requires_cuda_or_cdna
 def test_gemm_f32f32f32_nn():
     run_gemm(
         512,
@@ -170,7 +171,6 @@ def test_gemm_f32f32f32_nn():
     )
 
 
-@tilelang.testing.requires_cuda
 def test_gemm_f16f16f16_tn():
     run_gemm(
         512,
@@ -188,7 +188,6 @@ def test_gemm_f16f16f16_tn():
     )
 
 
-@tilelang.testing.requires_cuda
 def test_gemm_f16f16f16_nt():
     run_gemm(
         512,
@@ -206,23 +205,18 @@ def test_gemm_f16f16f16_nt():
     )
 
 
-@tilelang.testing.requires_cuda_or_cdna
 def test_gemm_i8i8i32_nt():
     run_gemm(512, 1024, 768, False, True, T.int8, T.int8, T.int32, 128, 128, 64)
 
 
-@tilelang.testing.requires_cuda_or_cdna
 def test_gemm_i8i8i32_tn():
     run_gemm(512, 1024, 768, True, False, T.int8, T.int8, T.int32, 128, 128, 64)
 
 
-@tilelang.testing.pytest.mark.xfail
-@tilelang.testing.requires_cuda
 def test_gemm_f64f64f64_nt():
     run_gemm(512, 512, 512, False, True, T.float64, T.float64, T.float64, 64, 32, 16)
 
 
-@tilelang.testing.requires_cuda_or_cdna
 def test_gemm_f32f32f32_nt():
     run_gemm(
         512,
@@ -239,8 +233,6 @@ def test_gemm_f32f32f32_nt():
     )
 
 
-# TODO(Gong): Meets precision issue on ROCm, disable for now
-@tilelang.testing.requires_cuda
 def test_gemm_f32f32f32_tn():
     run_gemm(
         512,
@@ -257,7 +249,6 @@ def test_gemm_f32f32f32_tn():
     )
 
 
-@tilelang.testing.requires_cuda
 def test_pad_aligned_f16f16f16_nn():
     run_gemm(
         512 - 8,
@@ -275,7 +266,6 @@ def test_pad_aligned_f16f16f16_nn():
     )
 
 
-@tilelang.testing.requires_cuda
 def test_pad_f16f16f16_nn():
     run_gemm(
         512 - 9,
@@ -410,8 +400,6 @@ def run_gemm_sr(
     profiler.assert_allclose(ref_program, atol=1e-2, rtol=1e-2)
 
 
-# WGMMA only supports B in shared
-@tilelang.testing.requires_cuda_compute_version_le(8, 9)
 def test_gemm_f16f16f16_sr():
     run_gemm_sr(
         512,
@@ -529,8 +517,6 @@ def run_gemm_rs(
     profiler.assert_allclose(ref_program, atol=1e-2, rtol=1e-2)
 
 
-# Register source A operand GMMAs must have K-major A layout.
-@tilelang.testing.requires_cuda_compute_version_le(8, 9)
 def test_gemm_f16f16f16_rs():
     run_gemm_rs(
         512,

--- a/tilelang/maca/intrinsics/layout/utils.py
+++ b/tilelang/maca/intrinsics/layout/utils.py
@@ -1,5 +1,10 @@
 from .mma_layout import thread_id_shared_access_64x4_to_16x16_layout_C_n_m
 
 
-def mma_store_index_map(thread_id, local_id):
+def mma_store_index_map(thread_id, local_id, is_float64=False):
+    if is_float64:
+        i = thread_id % 16
+        j = (thread_id // 16) + local_id * 4
+        return i, j
+
     return thread_id_shared_access_64x4_to_16x16_layout_C_n_m(thread_id, local_id)

--- a/tilelang/maca/intrinsics/macro/mma_macro_generator.py
+++ b/tilelang/maca/intrinsics/macro/mma_macro_generator.py
@@ -47,6 +47,7 @@ class TensorCoreIntrinEmitter:
         "float16": "fp16",
         "bfloat16": "bf16",
         "float32": "fp32",
+        "float64": "fp64",
         "int8": "int8",
         "int32": "int32",
         "float8_e4m3": "e4m3",
@@ -118,9 +119,11 @@ class TensorCoreIntrinEmitter:
                 return
             a_dtype = DataType(a_dtype)
 
-        if a_dtype.bits == 32:
+        if a_dtype.bits == 64:
+            self.k_dim = 4
+        elif a_dtype.bits == 32:
             self.k_dim = 8
-        elif a_dtype.bits == 16:
+        elif a_dtype.bits in {16, 8}:
             self.k_dim = 16
         elif a_dtype.bits == 8:
             target = determine_target(return_object=True)
@@ -163,6 +166,7 @@ class TensorCoreIntrinEmitter:
             "bfloat16": "bf16",
             "float16": "f16",
             "float32": "tf32",
+            "float64": "f64",
             "int8": "i8",
             "float8_e4m3": "f8",
             "float8_e4m3fn": "f8",
@@ -256,7 +260,10 @@ class TensorCoreIntrinEmitter:
 
     def get_store_index_map(self, inverse: bool = False) -> IndexMap:
         warp_size, local_size_c = self.WARP_SIZE, self.local_size_out
-        index_map = IndexMap.from_func(mma_store_index_map, index_dtype=T.int32)
+        is_float64 = DataType(self.accum_dtype).bits == 64
+        index_map = IndexMap.from_func(
+            lambda thread_id, local_id: mma_store_index_map(thread_id, local_id, is_float64=is_float64), index_dtype=T.int32
+        )
         if not inverse:
             return index_map
         inverse_index_map = index_map.inverse([warp_size, local_size_c])
@@ -446,13 +453,14 @@ class TensorCoreIntrinEmitter:
         M_DIM, N_DIM = self.M_DIM, self.N_DIM
         C_buf_dims = len(C_buf.shape)
         assert C_buf_dims in {2, 4}, "C_buf should be 2D or 4D"
+        is_float64 = DataType(self.accum_dtype).bits == 64
 
         @T.macro
         def _warp_stmatrix_shared(C_local_buf, C_buf, thread_binding):
             tx, warp_n, warp_m = self.extract_thread_binding(thread_binding)
             for i, j in T.grid(warp_rows, warp_cols):
                 for local_id in T.vectorized(local_size_out):
-                    row, col = T.meta_var(mma_store_index_map(tx, local_id))
+                    row, col = T.meta_var(mma_store_index_map(tx, local_id, is_float64=is_float64))
                     if C_buf_dims == 2:
                         C_buf[(warp_m * warp_rows + i) * M_DIM + row, (warp_n * warp_cols + j) * N_DIM + col] = C_local_buf[
                             i * (warp_cols * local_size_out) + j * local_size_out + local_id
@@ -467,7 +475,7 @@ class TensorCoreIntrinEmitter:
             tx, warp_n, warp_m = self.extract_thread_binding(thread_binding)
             for i, j in T.grid(warp_rows, warp_cols):
                 for local_id in T.vectorized(local_size_out):
-                    row, col = T.meta_var(mma_store_index_map(tx, local_id))
+                    row, col = T.meta_var(mma_store_index_map(tx, local_id, is_float64=is_float64))
                     C_buf[
                         (pid_m * BLOCK_M + warp_m * warp_rows + i) * M_DIM + row, (pid_n * BLOCK_N + warp_n * warp_cols + j) * N_DIM + col
                     ] = C_local_buf[i * warp_cols * local_size_out + j * local_size_out + local_id]

--- a/tilelang/maca/intrinsics/macro/mma_macro_generator.py
+++ b/tilelang/maca/intrinsics/macro/mma_macro_generator.py
@@ -119,11 +119,11 @@ class TensorCoreIntrinEmitter:
                 return
             a_dtype = DataType(a_dtype)
 
-        if a_dtype.bits == 64:
-            self.k_dim = 4
-        elif a_dtype.bits == 32:
+        if a_dtype.bits == 32:
             self.k_dim = 8
-        elif a_dtype.bits in {16, 8}:
+        elif a_dtype.bits == 64:
+            self.k_dim = 4
+        elif a_dtype.bits == 16:
             self.k_dim = 16
         elif a_dtype.bits == 8:
             target = determine_target(return_object=True)

--- a/tilelang/maca/intrinsics/macro/mma_sp_macro_generator.py
+++ b/tilelang/maca/intrinsics/macro/mma_sp_macro_generator.py
@@ -39,6 +39,7 @@ class SparseTensorCoreIntrinEmitter:
         "float16": "fp16",
         "bfloat16": "bf16",
         "float32": "fp32",
+        "float64": "fp64",
         "int8": "int8",
         "int32": "int32",
         "float8_e4m3": "e4m3",
@@ -126,7 +127,7 @@ class SparseTensorCoreIntrinEmitter:
                 return
             a_dtype = DataType(a_dtype)
 
-        if a_dtype.bits == 32:
+        if a_dtype.bits == 64 or a_dtype.bits == 32:
             self.k_dim = 4
         elif a_dtype.bits in {16, 8}:
             self.k_dim = 16
@@ -151,6 +152,7 @@ class SparseTensorCoreIntrinEmitter:
             "bfloat16": "bf16",
             "float16": "f16",
             "float32": "f32",
+            "float64": "f64",
             "int8": "i8",
             "int32": "i32",
             "float8_e4m3fn": "fp8",
@@ -198,7 +200,10 @@ class SparseTensorCoreIntrinEmitter:
 
     def get_store_index_map(self, inverse: bool = False) -> IndexMap:
         warp_size, local_size_c = self.WARP_SIZE, self.local_size_out
-        index_map = IndexMap.from_func(mma_store_index_map, index_dtype=T.int32)
+        is_float64 = DataType(self.accum_dtype).bits == 64
+        index_map = IndexMap.from_func(
+            lambda thread_id, local_id: mma_store_index_map(thread_id, local_id, is_float64=is_float64), index_dtype=T.int32
+        )
         if not inverse:
             return index_map
         inverse_index_map = index_map.inverse([warp_size, local_size_c])
@@ -427,6 +432,7 @@ class SparseTensorCoreIntrinEmitter:
         assert C_buf_dims in {2, 4}, "C_buf should be 2D or 4D"
 
         thread_binding = self.get_thread_binding()
+        is_float64 = DataType(self.accum_dtype).bits == 64
 
         # STS
         # MMA Store must be in simulated instead of TVM Intrins
@@ -439,7 +445,7 @@ class SparseTensorCoreIntrinEmitter:
                 for local_id_o in T.serial(local_size_out // 2):
                     for local_id_i in T.vectorized(2):
                         local_id = local_id_o * 2 + local_id_i
-                        row, col = T.meta_var(mma_store_index_map(tx, local_id))
+                        row, col = T.meta_var(mma_store_index_map(tx, local_id, is_float64=is_float64))
                         if C_buf_dims == 2:
                             C_buf[(warp_m * warp_rows + i) * M_DIM + row, (warp_n * warp_cols + j) * n_dim + col] = C_local_buf[
                                 i * (warp_cols * local_size_out) + j * local_size_out + local_id
@@ -456,7 +462,7 @@ class SparseTensorCoreIntrinEmitter:
                 for local_id_o in T.serial(local_size_out // 2):
                     for local_id_i in T.vectorized(2):
                         local_id = local_id_o * 2 + local_id_i
-                        row, col = T.meta_var(mma_store_index_map(tx, local_id))
+                        row, col = T.meta_var(mma_store_index_map(tx, local_id, is_float64=is_float64))
                         C_buf[
                             (pid_m * BLOCK_M + warp_m * warp_rows + i) * M_DIM + row,
                             (pid_n * BLOCK_N + warp_n * warp_cols + j) * n_dim + col,


### PR DESCRIPTION
The corresponding fp64 types have been added to the macro files, and the appropriate fp64 store calculation logic has been added to the utils file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended float64 data type support across tensor core matrix multiply-accumulate operations and sparse tensor operations.

* **Bug Fixes**
  * Improved 64-bit accumulation result storage indexing for accurate data placement in MMA operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->