### PR TITLE
[MetaxGPU][testing] Improved the generation of L2 persistence instruc…

### DIFF
--- a/src/maca/CMakeLists.txt
+++ b/src/maca/CMakeLists.txt
@@ -15,6 +15,8 @@ file(GLOB TILE_LANG_MACA_SRCS
   src/maca/runtime/maca_target_kind.cc
   src/maca/runtime/maca_device_api.cc
   src/cuda/transform/*.cc
+  src/maca/transform/*.cc
+  src/maca/runtime/maca_runtime.cc
 )
 list(APPEND TILE_LANG_SRCS ${TILE_LANG_MACA_SRCS})
 

--- a/src/maca/runtime/maca_runtime.cc
+++ b/src/maca/runtime/maca_runtime.cc
@@ -1,0 +1,111 @@
+/*!
+ * \file maca_runtime.cc
+ * \brief MACA L2 persisting cache access policy window helpers.
+ */
+
+#include "maca_runtime.h"
+
+#include "maca_common.h"
+
+#include <cstring>
+#include <tvm/ffi/function.h>
+#include <tvm/ffi/reflection/registry.h>
+
+namespace tvm {
+namespace tl {
+
+namespace {
+
+thread_local size_t __tl_prev_persisting_l2_cache_size = 0;
+thread_local bool __tl_prev_persisting_l2_cache_saved = false;
+
+} // namespace
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  refl::GlobalDef()
+      .def_packed(
+          tvm_maca_stream_set_access_policy_window,
+          [](ffi::PackedArgs args, ffi::Any *ret) {
+            TVM_FFI_ICHECK(args.size() >= 2)
+                << "Expected at least base_ptr and num_bytes";
+
+            void *base_ptr = args[0].cast<void *>();
+            size_t num_bytes = static_cast<size_t>(args[1].cast<int64_t>());
+            float hit_ratio = 0.8f;
+            if (args.size() >= 3) {
+              hit_ratio = static_cast<float>(args[2].cast<double>());
+            }
+            mcStream_t stream = nullptr;
+            if (args.size() >= 4) {
+              stream = reinterpret_cast<mcStream_t>(args[3].cast<void *>());
+            }
+            size_t l2_limit_bytes = num_bytes;
+            if (args.size() >= 5) {
+              l2_limit_bytes = static_cast<size_t>(args[4].cast<int64_t>());
+            }
+
+            int device_id = 0;
+            MACA_CALL(mcGetDevice(&device_id));
+            int max_persisting = 0;
+            mcError_t attrib_err = mcDeviceGetAttribute(
+                &max_persisting, mcDeviceAttributeMaxPersistingL2CacheSize,
+                device_id);
+            if (attrib_err == mcSuccess && max_persisting > 0 &&
+                l2_limit_bytes > static_cast<size_t>(max_persisting)) {
+              l2_limit_bytes = static_cast<size_t>(max_persisting);
+            }
+
+            size_t init_persisting_l2_cache_size = 0;
+            mcError_t limit_get_err = mcDeviceGetLimit(
+                &init_persisting_l2_cache_size, mcLimitPersistingL2CacheSize);
+            if (limit_get_err == mcSuccess) {
+              __tl_prev_persisting_l2_cache_size =
+                  init_persisting_l2_cache_size;
+              __tl_prev_persisting_l2_cache_saved = true;
+              mcDeviceSetLimit(mcLimitPersistingL2CacheSize, l2_limit_bytes);
+            }
+
+            mcStreamAttrValue stream_attribute;
+            std::memset(&stream_attribute, 0, sizeof(stream_attribute));
+            stream_attribute.accessPolicyWindow.base_ptr = base_ptr;
+            stream_attribute.accessPolicyWindow.num_bytes = l2_limit_bytes;
+            stream_attribute.accessPolicyWindow.hitRatio = hit_ratio;
+            stream_attribute.accessPolicyWindow.hitProp =
+                mcAccessPropertyPersisting;
+            stream_attribute.accessPolicyWindow.missProp =
+                mcAccessPropertyStreaming;
+
+            mcStreamSetAttribute(stream, mcStreamAttributeAccessPolicyWindow,
+                                 &stream_attribute);
+            *ret = 0;
+          })
+      .def_packed(
+          tvm_maca_stream_reset_access_policy_window,
+          [](ffi::PackedArgs args, ffi::Any *ret) {
+            mcStream_t stream = nullptr;
+            if (args.size() >= 1) {
+              stream = reinterpret_cast<mcStream_t>(args[0].cast<void *>());
+            }
+
+            mcStreamAttrValue stream_attribute;
+            std::memset(&stream_attribute, 0, sizeof(stream_attribute));
+            stream_attribute.accessPolicyWindow.num_bytes = 0;
+            mcStreamSetAttribute(stream, mcStreamAttributeAccessPolicyWindow,
+                                 &stream_attribute);
+            // On some MACA devices, mcCtxResetPersistingL2Cache is not
+            // supported and returns mcErrorNotSupported or mcErrorInvalidValue.
+            // We can safely ignore it.
+            mcCtxResetPersistingL2Cache();
+
+            if (__tl_prev_persisting_l2_cache_saved) {
+              mcDeviceSetLimit(mcLimitPersistingL2CacheSize,
+                               __tl_prev_persisting_l2_cache_size);
+              __tl_prev_persisting_l2_cache_saved = false;
+            }
+            *ret = 0;
+          });
+}
+
+} // namespace tl
+} // namespace tvm

--- a/src/maca/runtime/maca_runtime.h
+++ b/src/maca/runtime/maca_runtime.h
@@ -1,0 +1,19 @@
+/*!
+ * \file maca_runtime.h
+ * \brief MACA runtime helpers for TileLang.
+ */
+#ifndef TVM_TL_BACKEND_MACA_RUNTIME_H_
+#define TVM_TL_BACKEND_MACA_RUNTIME_H_
+
+namespace tvm {
+namespace tl {
+
+constexpr const char *tvm_maca_stream_set_access_policy_window =
+    "__tvm_maca_stream_set_access_policy_window";
+constexpr const char *tvm_maca_stream_reset_access_policy_window =
+    "__tvm_maca_stream_reset_access_policy_window";
+
+} // namespace tl
+} // namespace tvm
+
+#endif // TVM_TL_BACKEND_MACA_RUNTIME_H_

--- a/src/maca/transform/lower_maca_intrin.cc
+++ b/src/maca/transform/lower_maca_intrin.cc
@@ -1,0 +1,114 @@
+/*!
+ * \file tl/maca/transform/lower_maca_intrin.cc
+ * \brief Lower MACA target-specific intrinsics.
+ */
+
+#include "support/check.h"
+#include <tvm/ir/cast.h>
+#include <tvm/tirx/analysis.h>
+#include <tvm/tirx/builtin.h>
+#include <tvm/tirx/stmt.h>
+#include <tvm/tirx/transform.h>
+
+#include "backend/common/target_utils.h"
+#include "maca/runtime/maca_runtime.h"
+#include "op/builtin.h"
+
+namespace tvm {
+namespace tl {
+
+namespace attr {
+constexpr const char *kL2PersistentMap = "l2_persistent_map";
+} // namespace attr
+
+using namespace tirx;
+using namespace ffi;
+
+class LowerMACAIntrin {
+public:
+  static PrimFunc Substitute(PrimFunc f) {
+    Optional<Target> target = f->GetAttr<Target>(tvm::attr::kTarget);
+    if (!target.defined() || !TargetIsMaca(target.value())) {
+      return f;
+    }
+
+    Optional<Map<String, Array<PrimExpr>>> l2_map =
+        f->GetAttr<Map<String, Array<PrimExpr>>>(attr::kL2PersistentMap);
+    if (!l2_map.defined()) {
+      return f;
+    }
+
+    Array<Stmt> prologue_stmts;
+    for (const auto &kv : l2_map.value()) {
+      Buffer buf = FindBufferByName(f, kv.first);
+      if (!buf.defined()) {
+        continue;
+      }
+
+      const Array<PrimExpr> &args = kv.second;
+      ICHECK_GE(args.size(), 2);
+
+      Array<PrimExpr> packed_args;
+      packed_args.push_back(
+          StringImm(tvm_maca_stream_set_access_policy_window));
+      packed_args.push_back(MakeBasePtr(buf));
+      packed_args.push_back(args[1]);
+      packed_args.push_back(args[0]);
+      prologue_stmts.push_back(Evaluate(
+          Call(DataType::Int(32), builtin::tvm_call_packed(), packed_args)));
+    }
+
+    if (prologue_stmts.empty()) {
+      return f;
+    }
+
+    Array<PrimExpr> reset_args;
+    reset_args.push_back(StringImm(tvm_maca_stream_reset_access_policy_window));
+    Stmt epilogue_stmt = Evaluate(
+        Call(DataType::Int(32), builtin::tvm_call_packed(), reset_args));
+
+    PrimFuncNode *fptr = f.CopyOnWrite();
+    Stmt prologue = prologue_stmts.size() == 1 ? prologue_stmts[0]
+                                               : SeqStmt(prologue_stmts);
+    fptr->body = SeqStmt({prologue, fptr->body, epilogue_stmt});
+    return f;
+  }
+
+private:
+  static Buffer FindBufferByName(const PrimFunc &f, const String &name) {
+    for (const auto &kv : f->buffer_map) {
+      if (kv.second->name == name) {
+        return kv.second;
+      }
+    }
+    return Buffer();
+  }
+
+  static PrimExpr MakeBasePtr(const Buffer &buf) {
+    PrimExpr base_ptr = buf->data;
+    if (buf->elem_offset.defined() && !is_zero(buf->elem_offset)) {
+      PrimExpr byte_offset = buf->elem_offset * IntImm(buf->elem_offset.dtype(),
+                                                       buf->dtype.bytes());
+      base_ptr = Call(DataType::Handle(), builtin::handle_add_byte_offset(),
+                      {base_ptr, byte_offset});
+    }
+    return base_ptr;
+  }
+};
+
+using namespace tirx::transform;
+
+tvm::transform::Pass LowerMACAIntrin() {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
+    return LowerMACAIntrin::Substitute(f);
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.LowerMACAIntrin", {});
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = reflection;
+  refl::GlobalDef().def("tl.maca.transform.LowerMACAIntrin", LowerMACAIntrin);
+}
+
+} // namespace tl
+} // namespace tvm

--- a/testing/python/jit/test_tilelang_jit_tvm_ffi.py
+++ b/testing/python/jit/test_tilelang_jit_tvm_ffi.py
@@ -384,7 +384,6 @@ def test_tvm_ffi_im2col_tma_desc():
     )
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_tvm_ffi_l2_persistent_map():
     """Test L2 persistent cache annotation with elementwise add."""
@@ -424,11 +423,11 @@ def test_tvm_ffi_l2_persistent_map():
     kernel = elementwise_add_with_l2_cache(M, N)
 
     source = kernel.get_host_source()
-    assert "__tvm_cuda_stream_set_access_policy_window_packed" in source, (
-        "Expected __tvm_cuda_stream_set_access_policy_window_packed in the kernel source"
+    assert "__tvm_maca_stream_set_access_policy_window_packed" in source, (
+        "Expected __tvm_maca_stream_set_access_policy_window_packed in the kernel source"
     )
-    assert "__tvm_cuda_stream_reset_access_policy_window_packed" in source, (
-        "Expected __tvm_cuda_stream_reset_access_policy_window_packed in the kernel source"
+    assert "__tvm_maca_stream_reset_access_policy_window_packed" in source, (
+        "Expected __tvm_maca_stream_reset_access_policy_window_packed in the kernel source"
     )
 
     # Create test tensors

--- a/tilelang/maca/__init__.py
+++ b/tilelang/maca/__init__.py
@@ -3,3 +3,4 @@ from . import op  # noqa: F401
 from . import pipeline  # noqa: F401
 from . import target  # noqa: F401
 from . import execution_backend  # noqa: F401
+from . import transform  # noqa: F401

--- a/tilelang/maca/_ffi_api.py
+++ b/tilelang/maca/_ffi_api.py
@@ -1,0 +1,5 @@
+"""FFI APIs for MACA-specific TileLang transform."""
+
+import tvm_ffi
+
+tvm_ffi.init_ffi_api("tl.maca.transform", __name__)

--- a/tilelang/maca/pipeline.py
+++ b/tilelang/maca/pipeline.py
@@ -52,6 +52,8 @@ def MACAPassPipelineBodyPrologue(mod: IRModule, target: Target) -> IRModule:
     # Lower high-level tile operations to low-level operations
     mod = tilelang.transform.LowerTileOp()(mod)
 
+    # Lower l2 persistent map
+    mod = tilelang.cuda.transform.LowerL2Persistent()(mod)
     # Decouple type cast vectorization constraints before vectorization
     mod = tilelang.transform.DecoupleTypeCast()(mod)
     # Legalize vectorized loops to ensure they are valid
@@ -117,7 +119,8 @@ def MACAPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.LowerThreadAllreduce()(mod)
 
     mod = tilelang.cuda.transform.LowerLDGSTG()(mod)
-
+    mod = tilelang.cuda.transform.LowerHopperIntrin()(mod)
+    mod = tilelang.maca.transform.LowerMACAIntrin()(mod)
     mod = tilelang.transform.AnnotateDeviceRegions()(mod)
     mod = tilelang.transform.SplitHostDevice()(mod)
 

--- a/tilelang/maca/transform/__init__.py
+++ b/tilelang/maca/transform/__init__.py
@@ -1,0 +1,11 @@
+"""MACA-specific transformation frontends."""
+
+from .. import _ffi_api
+
+
+def LowerMACAIntrin():
+    """LowerMACAIntrin"""
+    return _ffi_api.LowerMACAIntrin()  # type: ignore
+
+
+__all__ = ["LowerMACAIntrin"]


### PR DESCRIPTION
This PR separates MACA's L2 persistent-related lowering into a new tl.maca.transform.LowerMACAIntrin pass. LowerL2Persistent continues to be responsible for collecting l2_persistent_map annotations, and LowerMACAIntrin then generates the corresponding packed runtime calls within the MACA pipeline; At the same time, relevant helpers are registered in the MACA native runtime, and L2 access policy API calls that are not yet fully supported by MACA are handled on a best-effort basis to prevent invalid argument errors from the underlying layer from affecting code generation and the execution flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime control for MACA persisting L2 cache access-policy windows, including set and reset behavior.
  * Introduced `LowerMACAIntrin` to inject the required prologue/epilogue for MACA targets using `l2_persistent_map`.
  * Updated the MACA pass pipeline to add MACA lowering at the correct stage (alongside related CUDA intrinsics).

* **Tests**
  * Removed the expected-failure marker for the L2 persistent map test and updated symbol checks to MACA-specific access-policy calls.

* **Chores**
  * Exposed MACA transformation APIs and registered the corresponding FFI bindings for top-level use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->