### PR TITLE
[MetaxGPU][testing] Fix the cases that report XFAIL under the cache, carver, and cuda directories.

### DIFF
--- a/src/maca/codegen/codegen_maca.cc
+++ b/src/maca/codegen/codegen_maca.cc
@@ -831,8 +831,8 @@ void CodeGenTileLangMACA::PrintVecBinaryOp(const std::string &op, DataType t,
               stream << "));\n";
             }
           } else {
-            // f32: reinterpret lane pairs as float2. For float4, pairs are at .x and .z;
-            // for ulonglong3/4, one float2 per field.
+            // f32: reinterpret lane pairs as float2. For float4, pairs are at
+            // .x and .z; for ulonglong3/4, one float2 per field.
             auto make_float_pair = [&](const std::string &vec_name,
                                        const std::string &field) {
               return "*(float2*)(&(" + vec_name + "." + field + "))";

--- a/src/maca/codegen/codegen_maca.cc
+++ b/src/maca/codegen/codegen_maca.cc
@@ -25,6 +25,21 @@ namespace tvm {
 namespace codegen {
 using namespace ffi;
 
+namespace {
+
+bool CanEmitPackedX2MathMACA(DataType t) {
+  int lanes = t.lanes();
+  if (lanes < 2 || lanes % 2 != 0) {
+    return false;
+  }
+  if (t.is_bfloat16() || t.is_float16()) {
+    return true;
+  }
+  return t.is_float() && t.bits() == 32;
+}
+
+} // namespace
+
 struct MACAMath {
   std::string operator()(DataType t, std::string name) const {
     if (t.is_float()) {
@@ -684,18 +699,50 @@ void CodeGenTileLangMACA::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
 void CodeGenTileLangMACA::PrintVecBinaryOp(const std::string &op, DataType t,
                                            PrimExpr lhs, PrimExpr rhs,
                                            std::ostream &os) { // NOLINT(*)
-  if (t.lanes() == 2) {
-    bool is_f32x2 = t.is_float() && t.bits() == 32;
+  // Fast-path for packed x2 arithmetic (float32x2, bfloat16x2, float16x2).
+  //
+  // For float32x2: PTX `.f32x2` instructions are available on SM100+.
+  // For bfloat16x2 / float16x2: native packed half-precision instructions
+  // (__hadd2, __hsub2, etc.) are available on SM80+ (bf16) / SM53+ (fp16).
+  // The tl::*2 C++ helpers have compile-time arch guards with scalar
+  // fallbacks, so we can emit them unconditionally for 16-bit types.
+  //
+  // When lanes > 2 and is even, we decompose the vector operation into
+  // lanes/2 independent x2 packed operations on consecutive pairs.
+  int lanes = t.lanes();
+  if (lanes >= 2 && lanes % 2 == 0) {
     bool is_bf16x2 = t.is_bfloat16();
     bool is_fp16x2 = t.is_float16();
-
-    bool should_emit = is_f32x2 || is_bf16x2 || is_fp16x2;
-
-    if (should_emit) {
-      // Map TIR binary-op strings to tl:: packed helpers.
-      // Note: fma (ternary) and abs (unary) cannot appear here.
+    if (CanEmitPackedX2MathMACA(t)) {
       std::string tl_func;
-      if (op == "+")
+      bool use_fma = false;
+      PrimExpr fma_a, fma_b, fma_c;
+
+      if (op == "+") {
+        // Fuse packed mul+add here instead of relying on NVCC to recover
+        // packed FMA from tl::mul2/tl::add2 (or the underlying __fmul2 /
+        // __fadd2-style helpers). Once the pairwise ops are emitted as
+        // separate calls, NVCC does not reliably contract them back to fma2.
+        auto try_fuse_mul_add = [&](const PrimExpr &maybe_mul,
+                                    const PrimExpr &addend) -> bool {
+          const MulNode *mul = maybe_mul.as<MulNode>();
+          if (mul == nullptr || mul->dtype != t || mul->a.dtype() != t ||
+              mul->b.dtype() != t || addend.dtype() != t) {
+            return false;
+          }
+          tl_func = "fma2";
+          use_fma = true;
+          fma_a = mul->a;
+          fma_b = mul->b;
+          fma_c = addend;
+          return true;
+        };
+        if (!try_fuse_mul_add(lhs, rhs)) {
+          try_fuse_mul_add(rhs, lhs);
+        }
+      }
+
+      if (tl_func.empty() && op == "+")
         tl_func = "add2";
       else if (op == "-")
         tl_func = "sub2";
@@ -705,30 +752,134 @@ void CodeGenTileLangMACA::PrintVecBinaryOp(const std::string &op, DataType t,
         tl_func = "min2";
       else if (op == "max")
         tl_func = "max2";
+      else if (op == "min_nan")
+        tl_func = "min2_nan";
+      else if (op == "max_nan")
+        tl_func = "max2_nan";
 
       if (!tl_func.empty()) {
-        bool need_cast = is_bf16x2 || is_fp16x2;
-        std::string native_type;
-        if (is_bf16x2) {
-          native_type = "bfloat16x2";
-        } else if (is_fp16x2) {
-          native_type = "float16x2";
-        }
+        // Decompose into lanes/2 independent x2 packed operations.
+        //
+        // Vector type → CUDA struct mapping:
+        //   bf16/fp16 x2..x8  -> uint1..uint4  (one packed x2 pair per field)
+        //   bf16/fp16 x12/x16 -> ulonglong3/4 (two packed x2 pairs per field)
+        //   f32x2  -> float2 {.x, .y}
+        //   f32x4  -> float4 {.x,.y,.z,.w}
+        //   f32x6/x8 -> ulonglong3/4 (one float2 pair per field)
+        //
+        // For bf16/fp16: each 32-bit field already packs a pair of elements,
+        //   so we apply tl::*2 on each field directly for <= 8 lanes. For
+        //   12/16 lanes, each 64-bit field stores two x2 pairs.
+        // For f32: float4 stores pairs at {x,z}; ulonglong3/4 stores one
+        //   float2 pair per field at {x,y,z,w}.
+        int num_pairs = lanes / 2;
+        static const char access[] = {'x', 'y', 'z', 'w'};
 
-        std::string lhs_str = PrintExpr(lhs);
-        std::string rhs_str = PrintExpr(rhs);
+        std::string sret = name_supply_->FreshName("_");
+        this->PrintIndent();
+        this->PrintType(t, stream);
+        stream << ' ' << sret << ";\n";
+        int ssa_scope = BeginScope();
+        {
+          std::vector<std::string> packed_vecs;
+          if (use_fma) {
+            packed_vecs = {
+                SSAGetID(PrintExpr(fma_a), fma_a.dtype()),
+                SSAGetID(PrintExpr(fma_b), fma_b.dtype()),
+                SSAGetID(PrintExpr(fma_c), fma_c.dtype()),
+            };
+          } else {
+            packed_vecs = {
+                SSAGetID(PrintExpr(lhs), lhs.dtype()),
+                SSAGetID(PrintExpr(rhs), rhs.dtype()),
+            };
+          }
 
-        if (need_cast) {
-          os << "tl::to_uint1(tl::" << tl_func << "("
-             << "tl::from_uint1<" << native_type << ">(" << lhs_str << "), "
-             << "tl::from_uint1<" << native_type << ">(" << rhs_str << ")))";
-        } else {
-          os << "tl::" << tl_func << "(" << lhs_str << ", " << rhs_str << ")";
+          if (is_bf16x2 || is_fp16x2) {
+            std::string native_type = is_bf16x2 ? "maca_bfloat162" : "half2";
+            auto make_half_pair = [&](const std::string &vec_name,
+                                      const std::string &field,
+                                      int pair_offset) {
+              std::string pair = "tl::from_uint1<";
+              pair += native_type;
+              pair += ">(";
+              if (lanes <= 8) {
+                pair += "*(uint1*)(&(";
+                pair += vec_name;
+                pair += ".";
+                pair += field;
+                pair += "))";
+              } else {
+                pair += "*(((uint1*)(&(";
+                pair += vec_name;
+                pair += ".";
+                pair += field;
+                pair += "))) + ";
+                pair += std::to_string(pair_offset);
+                pair += ")";
+              }
+              pair += ")";
+              return pair;
+            };
+            for (int p = 0; p < num_pairs; ++p) {
+              int field_idx = lanes <= 8 ? p : (p / 2);
+              ICHECK_LT(field_idx, 4);
+              int pair_offset = lanes <= 8 ? 0 : (p % 2);
+              std::string field(1, access[field_idx]);
+              std::vector<std::string> pair_args;
+              pair_args.reserve(packed_vecs.size());
+              for (const auto &vec_name : packed_vecs) {
+                pair_args.push_back(
+                    make_half_pair(vec_name, field, pair_offset));
+              }
+              this->PrintIndent();
+              if (lanes <= 8) {
+                stream << "*(uint1*)(&(" << sret << "." << field
+                       << ")) = tl::to_uint1(tl::" << tl_func << "(";
+              } else {
+                stream << "*(((uint1*)(&(" << sret << "." << field << "))) + "
+                       << pair_offset << ") = tl::to_uint1(tl::" << tl_func
+                       << "(";
+              }
+              stream << pair_args[0];
+              for (size_t i = 1; i < pair_args.size(); ++i) {
+                stream << ", " << pair_args[i];
+              }
+              stream << "));\n";
+            }
+          } else {
+            // f32: apply tl::*2 on each consecutive pair of float fields,
+            // reinterpreted as float2.
+            auto make_float_pair = [&](const std::string &vec_name,
+                                       const std::string &field) {
+              return "*(float2*)(&(" + vec_name + "." + field + "))";
+            };
+            for (int p = 0; p < num_pairs; ++p) {
+              int field_idx = lanes <= 4 ? (p * 2) : p;
+              ICHECK_LT(field_idx, 4);
+              std::string field(1, access[field_idx]);
+              std::vector<std::string> pair_args;
+              pair_args.reserve(packed_vecs.size());
+              for (const auto &vec_name : packed_vecs) {
+                pair_args.push_back(make_float_pair(vec_name, field));
+              }
+              this->PrintIndent();
+              stream << "*(float2*)(&(" << sret << "." << field
+                     << ")) = tl::" << tl_func << "(" << pair_args[0];
+              for (size_t i = 1; i < pair_args.size(); ++i) {
+                stream << ", " << pair_args[i];
+              }
+              stream << ");\n";
+            }
+          }
         }
+        EndScope(ssa_scope);
+        os << sret;
         return;
       }
     }
   }
+
   // Declare the result.
   std::string sret = name_supply_->FreshName("_");
   this->PrintIndent();
@@ -1905,9 +2056,9 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
     std::string native_type;
 
     if (dtype.is_bfloat16()) {
-      native_type = "bfloat16x2";
+      native_type = "maca_bfloat162";
     } else if (dtype.is_float16()) {
-      native_type = "float16x2";
+      native_type = "half2";
     }
 
     auto print_arg = [&](int idx) -> std::string {

--- a/src/maca/codegen/codegen_maca.cc
+++ b/src/maca/codegen/codegen_maca.cc
@@ -699,16 +699,7 @@ void CodeGenTileLangMACA::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
 void CodeGenTileLangMACA::PrintVecBinaryOp(const std::string &op, DataType t,
                                            PrimExpr lhs, PrimExpr rhs,
                                            std::ostream &os) { // NOLINT(*)
-  // Fast-path for packed x2 arithmetic (float32x2, bfloat16x2, float16x2).
-  //
-  // For float32x2: PTX `.f32x2` instructions are available on SM100+.
-  // For bfloat16x2 / float16x2: native packed half-precision instructions
-  // (__hadd2, __hsub2, etc.) are available on SM80+ (bf16) / SM53+ (fp16).
-  // The tl::*2 C++ helpers have compile-time arch guards with scalar
-  // fallbacks, so we can emit them unconditionally for 16-bit types.
-  //
-  // When lanes > 2 and is even, we decompose the vector operation into
-  // lanes/2 independent x2 packed operations on consecutive pairs.
+  // Fast-path for packed x2 arithmetic (float32x2, maca_bfloat162, half2).
   int lanes = t.lanes();
   if (lanes >= 2 && lanes % 2 == 0) {
     bool is_bf16x2 = t.is_bfloat16();
@@ -719,10 +710,8 @@ void CodeGenTileLangMACA::PrintVecBinaryOp(const std::string &op, DataType t,
       PrimExpr fma_a, fma_b, fma_c;
 
       if (op == "+") {
-        // Fuse packed mul+add here instead of relying on NVCC to recover
-        // packed FMA from tl::mul2/tl::add2 (or the underlying __fmul2 /
-        // __fadd2-style helpers). Once the pairwise ops are emitted as
-        // separate calls, NVCC does not reliably contract them back to fma2.
+        // Fuse packed mul+add here instead of emitting separate tl::mul2 and
+        // tl::add2 calls that may not contract back into tl::fma2.
         auto try_fuse_mul_add = [&](const PrimExpr &maybe_mul,
                                     const PrimExpr &addend) -> bool {
           const MulNode *mul = maybe_mul.as<MulNode>();
@@ -760,18 +749,12 @@ void CodeGenTileLangMACA::PrintVecBinaryOp(const std::string &op, DataType t,
       if (!tl_func.empty()) {
         // Decompose into lanes/2 independent x2 packed operations.
         //
-        // Vector type → CUDA struct mapping:
+        // Vector type → MACA struct mapping:
         //   bf16/fp16 x2..x8  -> uint1..uint4  (one packed x2 pair per field)
         //   bf16/fp16 x12/x16 -> ulonglong3/4 (two packed x2 pairs per field)
         //   f32x2  -> float2 {.x, .y}
         //   f32x4  -> float4 {.x,.y,.z,.w}
         //   f32x6/x8 -> ulonglong3/4 (one float2 pair per field)
-        //
-        // For bf16/fp16: each 32-bit field already packs a pair of elements,
-        //   so we apply tl::*2 on each field directly for <= 8 lanes. For
-        //   12/16 lanes, each 64-bit field stores two x2 pairs.
-        // For f32: float4 stores pairs at {x,z}; ulonglong3/4 stores one
-        //   float2 pair per field at {x,y,z,w}.
         int num_pairs = lanes / 2;
         static const char access[] = {'x', 'y', 'z', 'w'};
 
@@ -848,8 +831,8 @@ void CodeGenTileLangMACA::PrintVecBinaryOp(const std::string &op, DataType t,
               stream << "));\n";
             }
           } else {
-            // f32: apply tl::*2 on each consecutive pair of float fields,
-            // reinterpreted as float2.
+            // f32: reinterpret lane pairs as float2. For float4, pairs are at .x and .z;
+            // for ulonglong3/4, one float2 per field.
             auto make_float_pair = [&](const std::string &vec_name,
                                        const std::string &field) {
               return "*(float2*)(&(" + vec_name + "." + field + "))";

--- a/src/tl_templates/maca/common.h
+++ b/src/tl_templates/maca/common.h
@@ -431,10 +431,6 @@ template <typename T> TL_DEVICE ::uint1 to_uint1(T v) {
 //   1. float2          (FP32x2, scalar lanes -- no MACA f32 packed SDK API)
 //   2. maca_bfloat162  (BF16x2, MACA SDK __h*2 intrinsics)
 //   3. half2           (FP16x2, MACA SDK __h*2 intrinsics)
-//
-// MACA codegen emits explicit casts from uint1 to maca_bfloat162 or half2
-// via tl::from_uint1 / tl::to_uint1, matching the CUDA __nv_bfloat162 /
-// __half2 pattern.
 // =========================================================================
 
 // --- add2 ----------------------------------------------------------------

--- a/src/tl_templates/maca/common.h
+++ b/src/tl_templates/maca/common.h
@@ -424,128 +424,114 @@ template <typename T> TL_DEVICE ::uint1 to_uint1(T v) {
   return r;
 }
 
-//  --- add2
-//  --------------------------------------------------------------------------
+// =========================================================================
+// Packed x2 element-wise math helpers
+//
+// Each operation (add2, sub2, mul2, fma2, max2, min2, abs2) is provided for:
+//   1. float2          (FP32x2, scalar lanes -- no MACA f32 packed SDK API)
+//   2. maca_bfloat162  (BF16x2, MACA SDK __h*2 intrinsics)
+//   3. half2           (FP16x2, MACA SDK __h*2 intrinsics)
+//
+// MACA codegen emits explicit casts from uint1 to maca_bfloat162 or half2
+// via tl::from_uint1 / tl::to_uint1, matching the CUDA __nv_bfloat162 /
+// __half2 pattern.
+// =========================================================================
+
+// --- add2 ----------------------------------------------------------------
 
 TL_DEVICE float2 add2(float2 a, float2 b) {
   return make_float2(a.x + b.x, a.y + b.y);
 }
-TL_DEVICE float16x2 add2(float16x2 a, float16x2 b) { return a + b; }
 
-TL_DEVICE bfloat16x2 add2(bfloat16x2 a, bfloat16x2 b) {
-  bfloat16x2 out;
-  out.data[0] = a.data[0] + b.data[0];
-  out.data[1] = a.data[1] + b.data[1];
-  return out;
+TL_DEVICE maca_bfloat162 add2(maca_bfloat162 a, maca_bfloat162 b) {
+  return __hadd2(a, b);
 }
 
-//  --- sub2
-//  --------------------------------------------------------------------------
+TL_DEVICE half2 add2(half2 a, half2 b) { return __hadd2(a, b); }
+
+// --- sub2 ----------------------------------------------------------------
 
 TL_DEVICE float2 sub2(float2 a, float2 b) {
   return make_float2(a.x - b.x, a.y - b.y);
 }
 
-TL_DEVICE float16x2 sub2(float16x2 a, float16x2 b) { return a - b; }
-
-TL_DEVICE bfloat16x2 sub2(bfloat16x2 a, bfloat16x2 b) {
-  bfloat16x2 out;
-  out.data[0] = a.data[0] - b.data[0];
-  out.data[1] = a.data[1] - b.data[1];
-  return out;
+TL_DEVICE maca_bfloat162 sub2(maca_bfloat162 a, maca_bfloat162 b) {
+  return __hsub2(a, b);
 }
 
-//  --- mul2
-//  --------------------------------------------------------------------------
+TL_DEVICE half2 sub2(half2 a, half2 b) { return __hsub2(a, b); }
+
+// --- mul2 ----------------------------------------------------------------
 
 TL_DEVICE float2 mul2(float2 a, float2 b) {
   return make_float2(a.x * b.x, a.y * b.y);
 }
 
-TL_DEVICE float16x2 mul2(float16x2 a, float16x2 b) { return a * b; }
-
-TL_DEVICE bfloat16x2 mul2(bfloat16x2 a, bfloat16x2 b) {
-  bfloat16x2 out;
-  out.data[0] = a.data[0] * b.data[0];
-  out.data[1] = a.data[1] * b.data[1];
-  return out;
+TL_DEVICE maca_bfloat162 mul2(maca_bfloat162 a, maca_bfloat162 b) {
+  return __hmul2(a, b);
 }
 
-//  --- fma2
-//  --------------------------------------------------------------------------
+TL_DEVICE half2 mul2(half2 a, half2 b) { return __hmul2(a, b); }
+
+// --- fma2 ----------------------------------------------------------------
 
 TL_DEVICE float2 fma2(float2 a, float2 b, float2 c) {
   return make_float2(a.x * b.x + c.x, a.y * b.y + c.y);
 }
-TL_DEVICE float16x2 fma2(float16x2 a, float16x2 b, float16x2 c) {
-  return a * b + c;
-}
-TL_DEVICE bfloat16x2 fma2(bfloat16x2 a, bfloat16x2 b, bfloat16x2 c) {
-  bfloat16x2 out;
-  out.data[0] = a.data[0] * b.data[0] + c.data[0];
-  out.data[1] = a.data[1] * b.data[1] + c.data[1];
-  return out;
+
+TL_DEVICE maca_bfloat162 fma2(maca_bfloat162 a, maca_bfloat162 b,
+                              maca_bfloat162 c) {
+  return __hfma2(a, b, c);
 }
 
-//  --- max2
-//  --------------------------------------------------------------------------
+TL_DEVICE half2 fma2(half2 a, half2 b, half2 c) { return __hfma2(a, b, c); }
+
+// --- max2 ----------------------------------------------------------------
 
 TL_DEVICE float2 max2(float2 a, float2 b) {
   return make_float2(fmaxf(a.x, b.x), fmaxf(a.y, b.y));
 }
 
-TL_DEVICE float16x2 max2(float16x2 a, float16x2 b) {
-  float16x2 out;
-  out[0] = a[0] > b[0] ? a[0] : b[0];
-  out[1] = a[1] > b[1] ? a[1] : b[1];
-  return out;
+TL_DEVICE maca_bfloat162 max2(maca_bfloat162 a, maca_bfloat162 b) {
+  return __hmax2(a, b);
 }
 
-TL_DEVICE bfloat16x2 max2(bfloat16x2 a, bfloat16x2 b) {
-  bfloat16x2 out;
-  out.data[0] = (float(a.data[0]) > float(b.data[0])) ? a.data[0] : b.data[0];
-  out.data[1] = (float(a.data[1]) > float(b.data[1])) ? a.data[1] : b.data[1];
-  return out;
-}
+TL_DEVICE half2 max2(half2 a, half2 b) { return __hmax2(a, b); }
 
-//  --- min2
-//  --------------------------------------------------------------------------
+// --- min2 ----------------------------------------------------------------
 
 TL_DEVICE float2 min2(float2 a, float2 b) {
   return make_float2(fminf(a.x, b.x), fminf(a.y, b.y));
 }
 
-TL_DEVICE float16x2 min2(float16x2 a, float16x2 b) {
-  float16x2 out;
-  out[0] = (float(a[0]) < float(b[0])) ? a[0] : b[0];
-  out[1] = (float(a[1]) < float(b[1])) ? a[1] : b[1];
-  return out;
+TL_DEVICE maca_bfloat162 min2(maca_bfloat162 a, maca_bfloat162 b) {
+  return __hmin2(a, b);
 }
 
-TL_DEVICE bfloat16x2 min2(bfloat16x2 a, bfloat16x2 b) {
-  bfloat16x2 out;
-  out.data[0] = (float(a.data[0]) < float(b.data[0])) ? a.data[0] : b.data[0];
-  out.data[1] = (float(a.data[1]) < float(b.data[1])) ? a.data[1] : b.data[1];
-  return out;
+TL_DEVICE half2 min2(half2 a, half2 b) { return __hmin2(a, b); }
+
+// --- max2_nan ------------------------------------------------------------
+
+TL_DEVICE maca_bfloat162 max2_nan(maca_bfloat162 a, maca_bfloat162 b) {
+  return __hmax2_nan(a, b);
 }
 
-//  --- abs2
-//  --------------------------------------------------------------------------
+TL_DEVICE half2 max2_nan(half2 a, half2 b) { return __hmax2_nan(a, b); }
+
+// --- min2_nan ------------------------------------------------------------
+
+TL_DEVICE maca_bfloat162 min2_nan(maca_bfloat162 a, maca_bfloat162 b) {
+  return __hmin2_nan(a, b);
+}
+
+TL_DEVICE half2 min2_nan(half2 a, half2 b) { return __hmin2_nan(a, b); }
+
+// --- abs2 ----------------------------------------------------------------
 
 TL_DEVICE float2 abs2(float2 a) { return make_float2(fabsf(a.x), fabsf(a.y)); }
 
-TL_DEVICE float16x2 abs2(float16x2 a) {
-  float16x2 out;
-  out[0] = (a[0] < _Float16(0.0f)) ? -a[0] : a[0];
-  out[1] = (a[1] < _Float16(0.0f)) ? -a[1] : a[1];
-  return out;
-}
+TL_DEVICE maca_bfloat162 abs2(maca_bfloat162 a) { return __habs2(a); }
 
-TL_DEVICE bfloat16x2 abs2(bfloat16x2 a) {
-  bfloat16x2 out;
-  out.data[0] = (float(a.data[0]) < 0.0f) ? -a.data[0] : a.data[0];
-  out.data[1] = (float(a.data[1]) < 0.0f) ? -a.data[1] : a.data[1];
-  return out;
-}
+TL_DEVICE half2 abs2(half2 a) { return __habs2(a); }
 
 } // namespace tl

--- a/testing/python/cache/test_tilelang_kernel_cache.py
+++ b/testing/python/cache/test_tilelang_kernel_cache.py
@@ -33,7 +33,7 @@ from tilelang.cache import _dispatch_map
 BACKENDS = [
     "tvm_ffi",
     "cython",
-    "nvrtc",
+    pytest.param("mcrtc", marks=pytest.mark.xfail(reason="mcrtc adapter/cache not implemented")),
     "cutedsl",
 ]
 
@@ -64,7 +64,7 @@ class PostProcCounter:
     def register_callback(self, backend: str):
         """Register postproc callback for the given backend."""
         comment_prefix = "#" if backend == "cutedsl" else "//"
-        global_func = "tilelang_callback_cutedsl_postproc" if backend == "cutedsl" else "tilelang_callback_cuda_postproc"
+        global_func = "tilelang_callback_cutedsl_postproc" if backend == "cutedsl" else "tilelang_callback_maca_postproc"
 
         def callback(code, _):
             self.count += 1
@@ -131,7 +131,6 @@ def clean_cache_env(tmp_path, request):
     return cache_dir
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_disk_cache_with_postproc(clean_cache_env, backend):
@@ -210,7 +209,6 @@ def test_disk_cache_with_postproc(clean_cache_env, backend):
     torch.testing.assert_close(c1, c2)
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_cache_miss_detection(clean_cache_env, backend):
@@ -262,7 +260,6 @@ def test_cache_miss_detection(clean_cache_env, backend):
     assert counter.count == 2, f"Different function should cause cache miss, expected 2 calls, got {counter.count}"
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_cache_isolation_between_tests(clean_cache_env, backend):

--- a/testing/python/carver/test_tilelang_carver_cuda_driver_properties.py
+++ b/testing/python/carver/test_tilelang_carver_cuda_driver_properties.py
@@ -1,6 +1,6 @@
 import tilelang.testing
-from tilelang.carver.arch.driver.cuda_driver import (
-    get_cuda_device_properties,
+from tilelang.carver.arch.driver.maca_driver import (
+    get_maca_device_properties,
     get_device_name,
     get_shared_memory_per_block,
     get_device_attribute,
@@ -28,7 +28,7 @@ class _cudaDeviceAttrNames:
 
 @tilelang.testing.requires_cuda
 def test_driver_get_device_properties():
-    prop = get_cuda_device_properties()
+    prop = get_maca_device_properties()
     assert prop is not None, "Failed to get CUDA device properties"
     assert isinstance(prop, torch.cuda._CudaDeviceProperties), "Returned object is not of type _CudaDeviceProperties"
 
@@ -40,7 +40,6 @@ def test_device_get_device_name():
     assert tl_device_name == th_device_name, "Device names do not match"
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_device_get_shared_memory_per_block():
     tl_smem = get_shared_memory_per_block()
@@ -55,7 +54,6 @@ def test_device_get_persisting_l2_cache_size():
     assert tl_cache_size == driver_cache_size, "Persisting L2 cache size values do not match"
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_device_get_num_sms():
     tl_num_sms = get_num_sms()

--- a/testing/python/cuda/test_cuda_f32x2_intrinsics.py
+++ b/testing/python/cuda/test_cuda_f32x2_intrinsics.py
@@ -20,8 +20,6 @@ import tilelang.testing
 import pytest
 import torch
 
-SM100_TARGET = {"kind": "cuda", "arch": "sm_100"}
-SM80_TARGET = {"kind": "cuda", "arch": "sm_80"}
 DEFAULT_TARGET = tilelang.backend.target.determine_target(return_object=True)
 
 M = 128  # number of threads / element-pairs
@@ -158,7 +156,10 @@ _BINARY_OPS = [
 _DTYPES = ["float32", "bfloat16", "float16"]
 
 # Native cast types expected in codegen for 16-bit packed types
-_NATIVE_CAST_TYPE = {"bfloat16": "__nv_bfloat162", "float16": "__half2"}
+if DEFAULT_TARGET.kind.name == "maca":
+    _NATIVE_CAST_TYPE = {"bfloat16": "maca_bfloat162", "float16": "half2"}
+else:
+    _NATIVE_CAST_TYPE = {"bfloat16": "__nv_bfloat162", "float16": "__half2"}
 
 # Torch reference functions
 _TORCH_REFS = {
@@ -177,7 +178,6 @@ _TORCH_REFS = {
 # ===================================================================
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize("dtype_name", _DTYPES)
 @pytest.mark.parametrize("op_name,op_func", _BINARY_OPS, ids=[n for n, _ in _BINARY_OPS])
@@ -193,7 +193,6 @@ def test_codegen_binary(op_name, op_func, dtype_name):
         assert _NATIVE_CAST_TYPE[dtype_name] in src, f"Expected {_NATIVE_CAST_TYPE[dtype_name]} cast in CUDA source for {dtype_name}"
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize("dtype_name", _DTYPES)
 def test_codegen_fma2(dtype_name):
@@ -206,7 +205,6 @@ def test_codegen_fma2(dtype_name):
         assert _NATIVE_CAST_TYPE[dtype_name] in src, f"Expected {_NATIVE_CAST_TYPE[dtype_name]} cast in CUDA source for {dtype_name}"
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize("dtype_name", _DTYPES)
 def test_codegen_abs2(dtype_name):
@@ -227,13 +225,12 @@ _AUTO_VEC_OP_NAMES = list(_AUTO_VEC_OPS.keys())  # ["add", "sub", "mul"]
 
 
 # float32: auto-vectorization should emit tl::<op>2 on SM100+
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize("op_key", _AUTO_VEC_OP_NAMES)
 def test_codegen_auto_vec_f32(op_key):
     py_op, tl_func = _AUTO_VEC_OPS[op_key]
     func = _make_auto_vec_binary_kernel(py_op, T.float32)
-    src = _lower_to_cuda_source(func, target=SM100_TARGET)
+    src = _lower_to_cuda_source(func)
     assert f"tl::{tl_func}" in src, f"Expected tl::{tl_func} in SM100 auto-vectorised CUDA source for float32 {op_key}"
 
 
@@ -243,7 +240,7 @@ def test_codegen_auto_vec_f32(op_key):
 def test_codegen_auto_vec_f32_width8(op_key):
     py_op, tl_func = _AUTO_VEC_OPS[op_key]
     func = _make_auto_vec_binary_kernel(py_op, T.float32, width=8)
-    src = _lower_to_cuda_source(func, target=SM100_TARGET)
+    src = _lower_to_cuda_source(func)
     assert "\x00" not in src, "Generated CUDA source should not contain embedded NUL bytes"
     for field in "xyzw":
         assert f".{field})) = tl::{tl_func}(" in src, (
@@ -252,6 +249,7 @@ def test_codegen_auto_vec_f32_width8(op_key):
 
 
 # float32: auto-vectorization should NOT emit tl::<op>2 before SM100
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize("op_key", _AUTO_VEC_OP_NAMES)
 def test_codegen_auto_vec_f32_no_sm80(op_key):
@@ -261,15 +259,13 @@ def test_codegen_auto_vec_f32_no_sm80(op_key):
     assert f"tl::{tl_func}" not in src, f"tl::{tl_func} should NOT appear in SM80 auto-vectorised CUDA source for float32 {op_key}"
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_codegen_auto_vec_fma_f32():
     func = _make_auto_vec_fma_kernel(T.float32)
-    src = _lower_to_cuda_source(func, target=SM100_TARGET)
+    src = _lower_to_cuda_source(func)
     assert "tl::fma2" in src, "Expected tl::fma2 in SM100 auto-vectorised CUDA source for float32 mul+add"
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize("dtype_name", ["bfloat16", "float16"])
 def test_codegen_auto_vec_fma_half_types(dtype_name):
@@ -282,7 +278,6 @@ def test_codegen_auto_vec_fma_half_types(dtype_name):
 
 # bfloat16 / float16: auto-vectorization should emit tl::<op>2 on any target
 # (the C++ helpers have compile-time arch fallbacks).
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize("dtype_name", ["bfloat16", "float16"])
 @pytest.mark.parametrize("op_key", _AUTO_VEC_OP_NAMES)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved MACA backend code generation for even-lane vector binary operations using packed x2 arithmetic, including fused multiply-add where possible.
  * Updated packed bf16/fp16 math helpers to use native MACA intrinsics, with added NaN-aware min/max support.

* **Tests**
  * Improved target-aware codegen/intrinsic expectations for packed x2 operations.
  * Reduced unnecessary expected-failure markers so more checks run; added an expected-failure entry for the `mcrtc` backend and adjusted MACA-specific post-processing selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->