### PR TITLE
[MetaxGPU][quantize] Use portable C++ MXFP4 dequant on Maca

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,8 +288,12 @@ jobs:
             uv pip install -v -r requirements-test-rocm.txt
           elif [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
             uv pip install -r requirements-test-maca.txt
+            SITE=".venv/lib/python${{ matrix.python-version }}/site-packages"
             uv pip uninstall -y flash-linear-attention flash_linear_attention 2>/dev/null || true
-            uv pip install --no-deps --python-version 3.10.0 flash_linear_attention==0.4.0 -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
+            rm -rf "${SITE}/fla" "${SITE}"/flash_linear_attention*.dist-info "${SITE}"/flash-linear-attention*.dist-info
+            uv pip install --force-reinstall --no-deps --python-version 3.10.0 \
+              flash_linear_attention==0.4.0+metax3.7.2.0torch2.8 \
+              -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
           elif [[ "${{ matrix.runner.toolkit }}" == *"Metal"* ]]; then
             uv pip install -v -r requirements-test-metal.txt
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,12 +288,8 @@ jobs:
             uv pip install -v -r requirements-test-rocm.txt
           elif [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
             uv pip install -r requirements-test-maca.txt
-            SITE=".venv/lib/python${{ matrix.python-version }}/site-packages"
             uv pip uninstall -y flash-linear-attention flash_linear_attention 2>/dev/null || true
-            rm -rf "${SITE}/fla" "${SITE}"/flash_linear_attention*.dist-info "${SITE}"/flash-linear-attention*.dist-info
-            uv pip install --force-reinstall --no-deps --python-version 3.10.0 \
-              flash_linear_attention==0.4.0 \
-              -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
+            uv pip install --force-reinstall --no-deps --python-version 3.10.0 flash_linear_attention==0.4.0 -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
           elif [[ "${{ matrix.runner.toolkit }}" == *"Metal"* ]]; then
             uv pip install -v -r requirements-test-metal.txt
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,8 +288,7 @@ jobs:
             uv pip install -v -r requirements-test-rocm.txt
           elif [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
             uv pip install -r requirements-test-maca.txt
-            uv pip uninstall -y flash-linear-attention flash_linear_attention 2>/dev/null || true
-            uv pip install --force-reinstall --no-deps --python-version 3.10.0 flash_linear_attention==0.4.0 -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
+            uv pip install --no-deps --python-version 3.10.0 flash_linear_attention==0.4.0 -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
           elif [[ "${{ matrix.runner.toolkit }}" == *"Metal"* ]]; then
             uv pip install -v -r requirements-test-metal.txt
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,8 +287,9 @@ jobs:
           elif [[ "${{ matrix.runner.toolkit }}" == *"ROCm"* ]]; then
             uv pip install -v -r requirements-test-rocm.txt
           elif [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
-          uv pip install --no-deps --python-version 3.10.0 flash_linear_attention==0.4.0 -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
             uv pip install -r requirements-test-maca.txt
+            uv pip uninstall -y flash-linear-attention flash_linear_attention 2>/dev/null || true
+            uv pip install --no-deps --python-version 3.10.0 flash_linear_attention==0.4.0 -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
           elif [[ "${{ matrix.runner.toolkit }}" == *"Metal"* ]]; then
             uv pip install -v -r requirements-test-metal.txt
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,7 @@ jobs:
             uv pip install -v -r requirements-test-rocm.txt
           elif [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
             uv pip install -r requirements-test-maca.txt
-            uv pip install --no-deps --python-version 3.10.0 flash_linear_attention==0.4.0 -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
+            uv pip install --no-deps --python-version 3.10.0 flash_linear_attention==0.4.0+metax3.7.2.0torch2.8 -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
           elif [[ "${{ matrix.runner.toolkit }}" == *"Metal"* ]]; then
             uv pip install -v -r requirements-test-metal.txt
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
             uv pip uninstall -y flash-linear-attention flash_linear_attention 2>/dev/null || true
             rm -rf "${SITE}/fla" "${SITE}"/flash_linear_attention*.dist-info "${SITE}"/flash-linear-attention*.dist-info
             uv pip install --force-reinstall --no-deps --python-version 3.10.0 \
-              flash_linear_attention==0.4.0+metax3.7.2.0torch2.8 \
+              flash_linear_attention==0.4.0 \
               -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
           elif [[ "${{ matrix.runner.toolkit }}" == *"Metal"* ]]; then
             uv pip install -v -r requirements-test-metal.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,8 +287,8 @@ jobs:
           elif [[ "${{ matrix.runner.toolkit }}" == *"ROCm"* ]]; then
             uv pip install -v -r requirements-test-rocm.txt
           elif [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
+          uv pip install --no-deps --python-version 3.10.0 flash_linear_attention==0.4.0 -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
             uv pip install -r requirements-test-maca.txt
-            uv pip install --no-deps --python-version 3.10.0 flash_linear_attention==0.4.0+metax3.7.2.0torch2.8 -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
           elif [[ "${{ matrix.runner.toolkit }}" == *"Metal"* ]]; then
             uv pip install -v -r requirements-test-metal.txt
           else

--- a/.github/workflows/pr-regression-test-bot.yml
+++ b/.github/workflows/pr-regression-test-bot.yml
@@ -207,7 +207,13 @@ jobs:
           fi
           uv pip install -v -r requirements-test.txt
           if [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
-            uv pip install -v --no-deps --python-version 3.10.0 flash_linear_attention==0.4.0+metax3.5.3.9torch2.8 -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
+            uv pip install -r requirements-test-maca.txt
+            SITE="new/lib/python${{ matrix.python-version }}/site-packages"
+            uv pip uninstall -y flash-linear-attention flash_linear_attention 2>/dev/null || true
+            rm -rf "${SITE}/fla" "${SITE}"/flash_linear_attention*.dist-info "${SITE}"/flash-linear-attention*.dist-info
+            uv pip install --force-reinstall --no-deps --python-version 3.10.0 \
+              flash_linear_attention==0.4.0 \
+              -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
           fi
           uv pip install -v .
           if [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
@@ -229,7 +235,13 @@ jobs:
           fi
           uv pip install -v -r requirements-test.txt
           if [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
-            uv pip install -v --no-deps --python-version 3.10.0 flash_linear_attention==0.4.0+metax3.5.3.9torch2.8 -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
+            uv pip install -r requirements-test-maca.txt
+            SITE="old/lib/python${{ matrix.python-version }}/site-packages"
+            uv pip uninstall -y flash-linear-attention flash_linear_attention 2>/dev/null || true
+            rm -rf "${SITE}/fla" "${SITE}"/flash_linear_attention*.dist-info "${SITE}"/flash-linear-attention*.dist-info
+            uv pip install --force-reinstall --no-deps --python-version 3.10.0 \
+              flash_linear_attention==0.4.0 \
+              -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
           fi
           uv pip install -v .
           if [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
@@ -244,7 +256,13 @@ jobs:
           fi
           uv pip install -v -r requirements-test.txt
           if [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
-            uv pip install -v --no-deps --python-version 3.10.0 flash_linear_attention==0.4.0+metax3.5.3.9torch2.8 -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
+            uv pip install -r requirements-test-maca.txt
+            SITE="test_regression/lib/python${{ matrix.python-version }}/site-packages"
+            uv pip uninstall -y flash-linear-attention flash_linear_attention 2>/dev/null || true
+            rm -rf "${SITE}/fla" "${SITE}"/flash_linear_attention*.dist-info "${SITE}"/flash-linear-attention*.dist-info
+            uv pip install --force-reinstall --no-deps --python-version 3.10.0 \
+              flash_linear_attention==0.4.0 \
+              -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
           fi
 
       - name: Clear uv cache for self-hosted runners (if setup failed)

--- a/.github/workflows/pr-regression-test-bot.yml
+++ b/.github/workflows/pr-regression-test-bot.yml
@@ -207,7 +207,6 @@ jobs:
           fi
           uv pip install -v -r requirements-test.txt
           if [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
-            uv pip install -r requirements-test-maca.txt
             SITE="new/lib/python${{ matrix.python-version }}/site-packages"
             uv pip uninstall -y flash-linear-attention flash_linear_attention 2>/dev/null || true
             rm -rf "${SITE}/fla" "${SITE}"/flash_linear_attention*.dist-info "${SITE}"/flash-linear-attention*.dist-info
@@ -235,7 +234,6 @@ jobs:
           fi
           uv pip install -v -r requirements-test.txt
           if [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
-            uv pip install -r requirements-test-maca.txt
             SITE="old/lib/python${{ matrix.python-version }}/site-packages"
             uv pip uninstall -y flash-linear-attention flash_linear_attention 2>/dev/null || true
             rm -rf "${SITE}/fla" "${SITE}"/flash_linear_attention*.dist-info "${SITE}"/flash-linear-attention*.dist-info
@@ -256,7 +254,6 @@ jobs:
           fi
           uv pip install -v -r requirements-test.txt
           if [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
-            uv pip install -r requirements-test-maca.txt
             SITE="test_regression/lib/python${{ matrix.python-version }}/site-packages"
             uv pip uninstall -y flash-linear-attention flash_linear_attention 2>/dev/null || true
             rm -rf "${SITE}/fla" "${SITE}"/flash_linear_attention*.dist-info "${SITE}"/flash-linear-attention*.dist-info

--- a/.github/workflows/pr-regression-test-bot.yml
+++ b/.github/workflows/pr-regression-test-bot.yml
@@ -207,9 +207,7 @@ jobs:
           fi
           uv pip install -v -r requirements-test.txt
           if [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
-            SITE="new/lib/python${{ matrix.python-version }}/site-packages"
             uv pip uninstall -y flash-linear-attention flash_linear_attention 2>/dev/null || true
-            rm -rf "${SITE}/fla" "${SITE}"/flash_linear_attention*.dist-info "${SITE}"/flash-linear-attention*.dist-info
             uv pip install --force-reinstall --no-deps --python-version 3.10.0 \
               flash_linear_attention==0.4.0 \
               -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
@@ -234,9 +232,7 @@ jobs:
           fi
           uv pip install -v -r requirements-test.txt
           if [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
-            SITE="old/lib/python${{ matrix.python-version }}/site-packages"
             uv pip uninstall -y flash-linear-attention flash_linear_attention 2>/dev/null || true
-            rm -rf "${SITE}/fla" "${SITE}"/flash_linear_attention*.dist-info "${SITE}"/flash-linear-attention*.dist-info
             uv pip install --force-reinstall --no-deps --python-version 3.10.0 \
               flash_linear_attention==0.4.0 \
               -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
@@ -254,9 +250,7 @@ jobs:
           fi
           uv pip install -v -r requirements-test.txt
           if [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
-            SITE="test_regression/lib/python${{ matrix.python-version }}/site-packages"
             uv pip uninstall -y flash-linear-attention flash_linear_attention 2>/dev/null || true
-            rm -rf "${SITE}/fla" "${SITE}"/flash_linear_attention*.dist-info "${SITE}"/flash-linear-attention*.dist-info
             uv pip install --force-reinstall --no-deps --python-version 3.10.0 \
               flash_linear_attention==0.4.0 \
               -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com

--- a/.github/workflows/pr-regression-test-bot.yml
+++ b/.github/workflows/pr-regression-test-bot.yml
@@ -207,7 +207,6 @@ jobs:
           fi
           uv pip install -v -r requirements-test.txt
           if [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
-            uv pip uninstall -y flash-linear-attention flash_linear_attention 2>/dev/null || true
             uv pip install --force-reinstall --no-deps --python-version 3.10.0 \
               flash_linear_attention==0.4.0 \
               -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
@@ -232,7 +231,6 @@ jobs:
           fi
           uv pip install -v -r requirements-test.txt
           if [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
-            uv pip uninstall -y flash-linear-attention flash_linear_attention 2>/dev/null || true
             uv pip install --force-reinstall --no-deps --python-version 3.10.0 \
               flash_linear_attention==0.4.0 \
               -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
@@ -250,7 +248,6 @@ jobs:
           fi
           uv pip install -v -r requirements-test.txt
           if [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
-            uv pip uninstall -y flash-linear-attention flash_linear_attention 2>/dev/null || true
             uv pip install --force-reinstall --no-deps --python-version 3.10.0 \
               flash_linear_attention==0.4.0 \
               -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com

--- a/maint/scripts/regression_all.py
+++ b/maint/scripts/regression_all.py
@@ -57,7 +57,7 @@ def _parse_table(output: str) -> dict[str, float]:
 
 
 def _examples_root() -> Path:
-    return Path(__file__).resolve().parents[2] / "examples" / "maca"
+    return Path(__file__).resolve().parents[2] / "examples" 
 
 
 def _discover_bench_files(examples_root: Path) -> list[Path]:

--- a/maint/scripts/regression_all.py
+++ b/maint/scripts/regression_all.py
@@ -57,7 +57,7 @@ def _parse_table(output: str) -> dict[str, float]:
 
 
 def _examples_root() -> Path:
-    return Path(__file__).resolve().parents[2] / "examples" 
+    return Path(__file__).resolve().parents[2] / "examples"
 
 
 def _discover_bench_files(examples_root: Path) -> list[Path]:

--- a/tilelang/quantize/mxfp.py
+++ b/tilelang/quantize/mxfp.py
@@ -1,10 +1,5 @@
 from typing import Literal
-
-from tvm.target import Target
-
 from tilelang import language as T
-from tilelang.backend.target import determine_target
-from tilelang.rocm.target import target_is_gfx950, target_is_hip
 
 # Implementation asm for fp4 to bf16, using twiddling
 # Reference: https://github.com/triton-lang/triton/blob/main/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py#L11-L18
@@ -162,28 +157,6 @@ __device__ void decode_fp4_to_bf16(T1 *B_local, T2 *B_local_decode, const int N 
 """
 
 
-def _resolve_mxfp_target(target):
-    if target is not None and target != "auto":
-        return target
-    current = Target.current(allow_none=True)
-    if current is not None:
-        return current
-    return determine_target("auto", return_object=True)
-
-
-def _target_uses_portable_mxfp_dequant(target) -> bool:
-    """Return True for targets that cannot compile CUDA PTX inline asm (e.g. Maca, AMD gfx950)."""
-    if target is None:
-        return False
-    if not isinstance(target, Target):
-        target = Target(target)
-    if target.kind.name == "maca":
-        return True
-    if target_is_hip(target):
-        return target_is_gfx950(target)
-    return False
-
-
 def get_mxfp_intrin_group(
     out_dtype: Literal[T.float16, T.bfloat16] = T.bfloat16,
     source_format: Literal[T.int, T.uint] = T.uint,
@@ -222,26 +195,50 @@ def get_mxfp_intrin_group(
     assert source_format in [T.int, T.uint], f"Invalid source_format: {source_format}. Expected 'int' or 'uint'."
     assert storage_dtype in [T.int32, T.int8, T.uint8], f"Invalid storage_dtype: {storage_dtype}. Expected 'int32' or 'int8' or 'uint8'."
 
-    # Maca and AMD gfx950 cannot compile CUDA PTX; use portable C++ below.
-    # All other targets (NV, RDNA, MI300) use the default CUDA PTX path.
-    # target=None keeps the CUDA PTX default; only target="auto" resolves from context.
-    _resolved = _resolve_mxfp_target(target) if target == "auto" else target
-    _use_portable = _target_uses_portable_mxfp_dequant(_resolved)
+    # Detect AMD gfx950 / Maca targets to select portable C++ dequantization.
+    # All other targets (NV, RDNA, MI300) use the default CUDA PTX path below.
+    _is_gfx950 = False
+    _is_maca = False
+    if target is not None:
+        from tvm.target import Target
+
+        tvm_target = target if isinstance(target, Target) else Target(target)
+        _is_maca = tvm_target.kind.name == "maca"
+        try:
+            from tilelang.rocm.target import target_is_gfx950
+
+            _is_gfx950 = target_is_gfx950(target)
+        except (ImportError, ModuleNotFoundError, AttributeError):
+            # target_is_gfx950 unavailable in this build; assume non-gfx950.
+            pass
 
     dtype_map = {T.float16: "f16", T.bfloat16: "bf16"}
     func_name = f"decode_fp{source_bit}_to_{dtype_map[out_dtype]}"
     if use_twiddling:
         func_name += "_twiddling"
 
-    if _use_portable:
-        # Portable C++ path (Maca / AMD gfx950). Function name unchanged for call sites.
+    if _is_gfx950:
+        # AMD gfx950 path: use portable HIP C++ implementations.
+        # The function name stays the same so the call site is unchanged.
         if use_twiddling and source_bit == 4 and out_dtype == T.bfloat16:
             return {"func_name": func_name, "c_source": decode_f4_to_bf16_twiddling_hip}
         elif not use_twiddling and source_bit == 4 and out_dtype == T.bfloat16:
             return {"func_name": func_name, "c_source": decode_f4_to_bf16_simple_hip}
         else:
             raise AssertionError(
-                f"Portable MXFP dequant only supports source_bit=4 and out_dtype=bfloat16, "
+                f"AMD gfx950 MXFP dequant only supports source_bit=4 and out_dtype=bfloat16, "
+                f"got source_bit={source_bit}, out_dtype={out_dtype}"
+            )
+
+    elif _is_maca:
+        # Maca path: use portable C++ implementations (no CUDA PTX inline asm).
+        if use_twiddling and source_bit == 4 and out_dtype == T.bfloat16:
+            return {"func_name": func_name, "c_source": decode_f4_to_bf16_twiddling_hip}
+        elif not use_twiddling and source_bit == 4 and out_dtype == T.bfloat16:
+            return {"func_name": func_name, "c_source": decode_f4_to_bf16_simple_hip}
+        else:
+            raise AssertionError(
+                f"Maca MXFP dequant only supports source_bit=4 and out_dtype=bfloat16, "
                 f"got source_bit={source_bit}, out_dtype={out_dtype}"
             )
 

--- a/tilelang/quantize/mxfp.py
+++ b/tilelang/quantize/mxfp.py
@@ -163,7 +163,7 @@ __device__ void decode_fp4_to_bf16(T1 *B_local, T2 *B_local_decode, const int N 
 
 
 def _resolve_mxfp_target(target):
-    if target is not None:
+    if target is not None and target != "auto":
         return target
     current = Target.current(allow_none=True)
     if current is not None:
@@ -222,7 +222,9 @@ def get_mxfp_intrin_group(
 
     # Maca and AMD gfx950 cannot compile CUDA PTX; use portable C++ below.
     # All other targets (NV, RDNA, MI300) use the default CUDA PTX path.
-    _use_portable = _target_uses_portable_mxfp_dequant(_resolve_mxfp_target(target))
+    # target=None keeps the CUDA PTX default; only target="auto" resolves from context.
+    _resolved = _resolve_mxfp_target(target) if target == "auto" else target
+    _use_portable = _target_uses_portable_mxfp_dequant(_resolved)
 
     dtype_map = {T.float16: "f16", T.bfloat16: "bf16"}
     func_name = f"decode_fp{source_bit}_to_{dtype_map[out_dtype]}"

--- a/tilelang/quantize/mxfp.py
+++ b/tilelang/quantize/mxfp.py
@@ -1,5 +1,10 @@
 from typing import Literal
+
+from tvm.target import Target
+
 from tilelang import language as T
+from tilelang.backend.target import determine_target
+from tilelang.rocm.target import target_is_gfx950
 
 # Implementation asm for fp4 to bf16, using twiddling
 # Reference: https://github.com/triton-lang/triton/blob/main/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py#L11-L18
@@ -157,6 +162,26 @@ __device__ void decode_fp4_to_bf16(T1 *B_local, T2 *B_local_decode, const int N 
 """
 
 
+def _resolve_mxfp_target(target):
+    if target is not None:
+        return target
+    current = Target.current(allow_none=True)
+    if current is not None:
+        return current
+    return determine_target("auto", return_object=True)
+
+
+def _target_uses_portable_mxfp_dequant(target) -> bool:
+    """Return True for targets that cannot compile CUDA PTX inline asm (e.g. Maca, AMD gfx950)."""
+    if target is None:
+        return False
+    if not isinstance(target, Target):
+        target = Target(target)
+    if target.kind.name == "maca":
+        return True
+    return target_is_gfx950(target)
+
+
 def get_mxfp_intrin_group(
     out_dtype: Literal[T.float16, T.bfloat16] = T.bfloat16,
     source_format: Literal[T.int, T.uint] = T.uint,
@@ -195,33 +220,24 @@ def get_mxfp_intrin_group(
     assert source_format in [T.int, T.uint], f"Invalid source_format: {source_format}. Expected 'int' or 'uint'."
     assert storage_dtype in [T.int32, T.int8, T.uint8], f"Invalid storage_dtype: {storage_dtype}. Expected 'int32' or 'int8' or 'uint8'."
 
-    # Detect AMD gfx950 target to select the HIP C++ dequantization implementation.
-    # All other targets (NV, RDNA, MI300) use the default CUDA PTX path below.
-    _is_gfx950 = False
-    if target is not None:
-        try:
-            from tilelang.rocm.target import target_is_gfx950
-
-            _is_gfx950 = target_is_gfx950(target)
-        except (ImportError, ModuleNotFoundError, AttributeError):
-            # target_is_gfx950 unavailable in this build; assume non-gfx950.
-            pass
+    # Maca and AMD gfx950 cannot compile CUDA PTX; use portable C++ below.
+    # All other targets (NV, RDNA, MI300) use the default CUDA PTX path.
+    _use_portable = _target_uses_portable_mxfp_dequant(_resolve_mxfp_target(target))
 
     dtype_map = {T.float16: "f16", T.bfloat16: "bf16"}
     func_name = f"decode_fp{source_bit}_to_{dtype_map[out_dtype]}"
     if use_twiddling:
         func_name += "_twiddling"
 
-    if _is_gfx950:
-        # AMD gfx950 path: use portable HIP C++ implementations.
-        # The function name stays the same so the call site is unchanged.
+    if _use_portable:
+        # Portable C++ path (Maca / AMD gfx950). Function name unchanged for call sites.
         if use_twiddling and source_bit == 4 and out_dtype == T.bfloat16:
             return {"func_name": func_name, "c_source": decode_f4_to_bf16_twiddling_hip}
         elif not use_twiddling and source_bit == 4 and out_dtype == T.bfloat16:
             return {"func_name": func_name, "c_source": decode_f4_to_bf16_simple_hip}
         else:
             raise AssertionError(
-                f"AMD gfx950 MXFP dequant only supports source_bit=4 and out_dtype=bfloat16, "
+                f"Portable MXFP dequant only supports source_bit=4 and out_dtype=bfloat16, "
                 f"got source_bit={source_bit}, out_dtype={out_dtype}"
             )
 

--- a/tilelang/quantize/mxfp.py
+++ b/tilelang/quantize/mxfp.py
@@ -4,7 +4,7 @@ from tvm.target import Target
 
 from tilelang import language as T
 from tilelang.backend.target import determine_target
-from tilelang.rocm.target import target_is_gfx950
+from tilelang.rocm.target import target_is_gfx950, target_is_hip
 
 # Implementation asm for fp4 to bf16, using twiddling
 # Reference: https://github.com/triton-lang/triton/blob/main/python/triton_kernels/triton_kernels/tensor_details/layout_details/hopper_value.py#L11-L18
@@ -179,7 +179,9 @@ def _target_uses_portable_mxfp_dequant(target) -> bool:
         target = Target(target)
     if target.kind.name == "maca":
         return True
-    return target_is_gfx950(target)
+    if target_is_hip(target):
+        return target_is_gfx950(target)
+    return False
 
 
 def get_mxfp_intrin_group(

--- a/tilelang/quantize/mxfp.py
+++ b/tilelang/quantize/mxfp.py
@@ -238,8 +238,7 @@ def get_mxfp_intrin_group(
             return {"func_name": func_name, "c_source": decode_f4_to_bf16_simple_hip}
         else:
             raise AssertionError(
-                f"Maca MXFP dequant only supports source_bit=4 and out_dtype=bfloat16, "
-                f"got source_bit={source_bit}, out_dtype={out_dtype}"
+                f"Maca MXFP dequant only supports source_bit=4 and out_dtype=bfloat16, got source_bit={source_bit}, out_dtype={out_dtype}"
             )
 
     # CUDA / default path: use PTX inline assembly implementations.


### PR DESCRIPTION
Maca mxcc rejects PTX inline asm in decode_fp4_to_bf16_twiddling.
Select the existing portable C++ path for Maca and gfx950, and infer
target from determine_target("auto") when not passed explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MXFP dequantization compatibility by automatically choosing a portable dequantization path on targets that can’t run CUDA PTX inline assembly, fixing correctness for affected AMD/MACA configurations.
  * Refined target selection so the MXFP implementation matches the active hardware capability set.

* **Chores**
  * Updated regression discovery to run benchmark driver scripts from the top-level `examples` directory instead of only `examples/maca`.
  * Improved MACA CI setup by fully removing any existing `flash_linear_attention`/`flash-linear-attention` installs (including related metadata) before installing the specified MetaX version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->