### PR TITLE
[MetaxGPU][testing ]fix test_tilelang_transform_lexical_alloc_scope.py xfail

### DIFF
--- a/src/maca/codegen/codegen_maca.cc
+++ b/src/maca/codegen/codegen_maca.cc
@@ -2466,7 +2466,16 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
 }
 
 void CodeGenTileLangMACA::VisitStmt_(const AttrStmtNode *op) {
-  if (op->attr_key == s_tir::attr::fragment_shape) {
+  if (op->attr_key == tl::attr::kLexicalAllocScope) {
+    PrintIndent();
+    stream << "{\n";
+    int scope = BeginScope();
+    PrintStmt(op->body);
+    EndScope(scope);
+    PrintIndent();
+    stream << "}\n";
+    return;
+  } else if (op->attr_key == s_tir::attr::fragment_shape) {
     const VarNode *buffer = op->node.as<VarNode>();
     const StringImmNode *shape_str = op->value.as<StringImmNode>();
     fragment_shapes[buffer] = shape_str->value;

--- a/testing/python/transform/test_tilelang_transform_lexical_alloc_scope.py
+++ b/testing/python/transform/test_tilelang_transform_lexical_alloc_scope.py
@@ -155,11 +155,10 @@ def test_lower_opaque_block_skips_empty_alloc():
 # ---------------------------------------------------------------------------
 # Test 4: GEMM descriptor allocs inside loop should get the marker
 # ---------------------------------------------------------------------------
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_lower_opaque_block_inserts_scope_for_gemm_descriptor_alloc():
     """Lowered WGMMA descriptor buffers inside a loop should trigger lexical_alloc_scope."""
-    target = tl.utils.determine_target(return_object=True)
+    target = tl.backend.target.determine_target(return_object=True)
 
     @T.prim_func
     def func(
@@ -274,11 +273,10 @@ def test_lower_opaque_block_skips_fragment_alloc():
 # ---------------------------------------------------------------------------
 # Test 8: disable-ws pipelined GEMM should not wrap the fragment root block
 # ---------------------------------------------------------------------------
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_lower_opaque_block_skips_fragment_root_in_disable_ws_pipeline():
     """A fragment root block should not force lexical_alloc_scope in disable-ws pipeline."""
-    target = tl.utils.determine_target(return_object=True)
+    target = tl.backend.target.determine_target(return_object=True)
     pass_configs = {tl.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED.value: True}
 
     @T.prim_func
@@ -348,7 +346,6 @@ def test_storage_rewrite_preserves_scope():
 # ---------------------------------------------------------------------------
 # Test 10: CUDA codegen emits { } for the scope
 # ---------------------------------------------------------------------------
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_codegen_emits_braces():
     """The generated CUDA source should contain scoped { } blocks for explicitly marked allocs."""
@@ -376,7 +373,6 @@ def test_codegen_emits_braces():
     assert len(standalone_open_braces) >= 1, f"Expected at least 1 standalone '{{' for lexical scope, found {len(standalone_open_braces)}"
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_codegen_skips_redundant_top_level_braces():
     """The outermost top-level lexical scope should not emit a redundant brace block."""


### PR DESCRIPTION
fix test_tilelang_transform_lexical_alloc_scope.py xfail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary
- Added explicit handling for `tl::attr::kLexicalAllocScope` in `CodeGenTileLangMACA::VisitStmt_`, emitting the body in a nested scope with `BeginScope()`/`EndScope()` and braces so lexical alloc blocks are codegenerated correctly.
- Updated the lexical alloc scope Python tests to run normally on CUDA instead of being marked xfail, including the GEMM descriptor allocation test, the disable-warp-specialized fragment-root pipeline test, and the CUDA brace-emission coverage.

### C++ style / lint notes
- This PR touches C++ code, but it does not appear to change rules documented in `docs/developer_guide/cpp_style.md`.
- No new correctness or build issues are indicated by the change summary.
- If the CI includes the “C++ API Style Audit (warning only)” step, any findings here should be treated as advisory unless they expose a clear maintainability or API risk; no such risk is apparent from the described changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->