### PR TITLE
[MetaxGPU][testing] fix test_tilelang_language_reduce.py nan xfail

### DIFF
--- a/src/maca/codegen/codegen_maca.cc
+++ b/src/maca/codegen/codegen_maca.cc
@@ -2037,8 +2037,8 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
   } else if (op->op.same_as(tl::add2()) || op->op.same_as(tl::sub2()) ||
              op->op.same_as(tl::mul2()) || op->op.same_as(tl::fma2()) ||
              op->op.same_as(tl::max2()) || op->op.same_as(tl::min2()) ||
-             op_ > op.same_as(tl::max2_nan()) ||
-             op->op.same_as(tl::min2_nan()) || op->op.same_as(tl::abs2())) {
+             op->op.same_as(tl::max2_nan()) || op->op.same_as(tl::min2_nan()) ||
+             op->op.same_as(tl::abs2())) {
     std::string op_name;
     if (op->op.same_as(tl::add2()))
       op_name = "add2";

--- a/src/maca/codegen/codegen_maca.cc
+++ b/src/maca/codegen/codegen_maca.cc
@@ -2015,10 +2015,30 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
       os << "_double";
     }
     os << "(&" << this->mcrand_random_generator_state << ")";
+  } else if (op->op.same_as(tl::max_nan()) || op->op.same_as(tl::min_nan())) {
+    ICHECK_EQ(op->args.size(), 2);
+    const bool is_max = op->op.same_as(tl::max_nan());
+    const DataType t = op->dtype;
+    std::string arg0 = PrintExpr(op->args[0]);
+    std::string arg1 = PrintExpr(op->args[1]);
+
+    if ((t.is_bfloat16() || t.is_float16()) && t.is_scalar()) {
+      const char *intrin = is_max ? "_hmax_nan" : "__hmin_nan";
+      os << intrin << "(" << arg0 << ", " << arg1 << ")";
+      return;
+    }
+    // Fallback to the regular max/min for other types
+    if (is_max) {
+      os << "max(" << arg0 << ", " << arg1 << ")";
+    } else {
+      os << "min(" << arg0 << ", " << arg1 << ")";
+    }
+    return;
   } else if (op->op.same_as(tl::add2()) || op->op.same_as(tl::sub2()) ||
              op->op.same_as(tl::mul2()) || op->op.same_as(tl::fma2()) ||
              op->op.same_as(tl::max2()) || op->op.same_as(tl::min2()) ||
-             op->op.same_as(tl::abs2())) {
+             op_ > op.same_as(tl::max2_nan()) ||
+             op->op.same_as(tl::min2_nan()) || op->op.same_as(tl::abs2())) {
     std::string op_name;
     if (op->op.same_as(tl::add2()))
       op_name = "add2";
@@ -2032,6 +2052,10 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
       op_name = "max2";
     else if (op->op.same_as(tl::min2()))
       op_name = "min2";
+    else if (op->op.same_as(tl::max2_nan()))
+      op_name = "max2_nan";
+    else if (op->op.same_as(tl::min2_nan()))
+      op_name = "min2_nan";
     else
       op_name = "abs2";
 
@@ -2780,8 +2804,30 @@ void CodeGenTileLangMACA::VisitExpr_(const ShuffleNode *op,
       enable_fp16_ = true;
       // __pack_half2 returns __half2 which is 32-bit.
       // Reinterpret via aggregate initialisation.
-      os << "uint1{*(unsigned)&(__pack_half2((__half)(" << e0 << "), (__half)("
+      os << "uint1{*(unsigned*)&(__pack_half2((__half)(" << e0 << "), (__half)("
          << e1 << ")))}";
+    }
+    return;
+  }
+  // Handle ExtractElement: extract a scalar lane from a bfloat16x2 / float16x2
+  // vector (produced by packed reduction, etc.). The vector is stored as an
+  // opaque uint1 in the lowered code, but semantically it is a packed pair.
+  DataType vec_t =
+      op->vectors.size() == 1 ? op->vectors[0].dtype() : DataType();
+  bool vec_is_bf16x2 = vec_t.is_bfloat16() && vec_t.lanes() == 2;
+  bool vec_is_fp16x2 = vec_t.is_float16() && vec_t.lanes() == 2;
+  if ((vec_is_bf16x2 || vec_is_fp16x2) && op->vectors.size() == 1 &&
+      op->indices.size() == 1) {
+    int lane = Downcast<IntImm>(op->indices[0])->value;
+    std::string vec = PrintExpr(op->vectors[0]);
+    if (vec_is_bf16x2) {
+      enable_bf16_ = true;
+      os << "bfloat16_t(((maca_bfloat162*)(&(" << vec << ")))->"
+         << (lane == 0 ? "x" : "y") << ")";
+    } else {
+      enable_fp16_ = true;
+      os << "half_t(((half2*)(&(" << vec << ")))->" << (lane == 0 ? "x" : "y")
+         << ")";
     }
     return;
   }

--- a/src/maca/codegen/codegen_maca.cc
+++ b/src/maca/codegen/codegen_maca.cc
@@ -2804,8 +2804,7 @@ void CodeGenTileLangMACA::VisitExpr_(const ShuffleNode *op,
       enable_fp16_ = true;
       // __pack_half2 returns __half2 which is 32-bit.
       // Reinterpret via aggregate initialisation.
-      os << "uint1{*(unsigned*)&(__pack_half2((__half)(" << e0 << "), (__half)("
-         << e1 << ")))}";
+      os << "uint1{tl::pack_half2(" << e0 << "," << e1 << ")}";
     }
     return;
   }

--- a/src/maca/codegen/codegen_maca.cc
+++ b/src/maca/codegen/codegen_maca.cc
@@ -2023,7 +2023,7 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
     std::string arg1 = PrintExpr(op->args[1]);
 
     if ((t.is_bfloat16() || t.is_float16()) && t.is_scalar()) {
-      const char *intrin = is_max ? "_hmax_nan" : "__hmin_nan";
+      const char *intrin = is_max ? "__hmax_nan" : "__hmin_nan";
       os << intrin << "(" << arg0 << ", " << arg1 << ")";
       return;
     }

--- a/src/maca/op/reduce.cc
+++ b/src/maca/op/reduce.cc
@@ -21,7 +21,12 @@ struct Reduce : backend::ReduceLowerer<Reduce> {
     return TargetIsMaca(target);
   }
 
-  static int GetPreferedVectorizedSize(DataType dt, Target target) { return 1; }
+  static int GetPreferedVectorizedSize(DataType dt, Target target) {
+    if (!TargetIsMaca(target)) {
+      return 1;
+    }
+    return backend::reduce::GetPreferedVectorizedSize(dt);
+  }
 
   static std::string MakeBatchAllReduce(std::string reducer,
                                         int reducing_threads, int scale,

--- a/src/tl_templates/maca/common.h
+++ b/src/tl_templates/maca/common.h
@@ -398,15 +398,65 @@ TL_DEVICE void __sync_thread_partial() {
 //
 namespace tl {
 
-// Generic passthroughs
+template <int LaneMask> TL_DEVICE uint32_t shfl_xor_u32_imm(uint32_t v) {
+  static_assert(LaneMask == 1 || LaneMask == 2 || LaneMask == 4 ||
+                    LaneMask == 8,
+                "unsupported row-local XOR lane mask");
+  if constexpr (LaneMask == 1) {
+    // Quad permutation: [0, 1, 2, 3] -> [1, 0, 3, 2].
+    return static_cast<uint32_t>(__builtin_mxc_update_shfl(
+        static_cast<int>(v), static_cast<int>(v), 0x0b1, 0xf, 0xf, false));
+  } else if constexpr (LaneMask == 2) {
+    // Quad permutation: [0, 1, 2, 3] -> [2, 3, 0, 1].
+    return static_cast<uint32_t>(__builtin_mxc_update_shfl(
+        static_cast<int>(v), static_cast<int>(v), 0x04e, 0xf, 0xf, false));
+  } else if constexpr (LaneMask == 4) {
+    // XOR 4 within a 16-lane row is two masked row shifts:
+    // banks 0/2 read from +4, banks 1/3 read from -4.
+    uint32_t out = v;
+    out = static_cast<uint32_t>(__builtin_mxc_update_shfl(
+        static_cast<int>(out), static_cast<int>(v), 0x104, 0xf, 0x5, false));
+    out = static_cast<uint32_t>(__builtin_mxc_update_shfl(
+        static_cast<int>(out), static_cast<int>(v), 0x114, 0xf, 0xa, false));
+    return out;
+  } else if constexpr (LaneMask == 8) {
+    // Row rotate right by 8 is equivalent to XOR 8 within a 16-lane row.
+    return static_cast<uint32_t>(__builtin_mxc_update_shfl(
+        static_cast<int>(v), static_cast<int>(v), 0x128, 0xf, 0xf, false));
+  } else {
+    return v;
+  }
+}
+
+template <int LaneMask, typename T> TL_DEVICE T shfl_xor_imm(T val) {
+  if constexpr (sizeof(T) <= sizeof(uint32_t)) {
+    uint32_t bits = 0;
+    __builtin_memcpy(&bits, &val, sizeof(T));
+    bits = shfl_xor_u32_imm<LaneMask>(bits);
+    T out;
+    __builtin_memcpy(&out, &bits, sizeof(T));
+    return out;
+  } else if constexpr (sizeof(T) == 2 * sizeof(uint32_t)) {
+    uint32_t bits[2];
+    __builtin_memcpy(bits, &val, sizeof(T));
+    bits[0] = shfl_xor_u32_imm<LaneMask>(bits[0]);
+    bits[1] = shfl_xor_u32_imm<LaneMask>(bits[1]);
+    T out;
+    __builtin_memcpy(&out, bits, sizeof(T));
+    return out;
+  } else {
+    return val;
+  }
+}
+
 template <typename T>
-TL_DEVICE T shfl_xor_sync(uint64_t mask, T val, int laneMask) {
+TL_DEVICE T shfl_xor_sync_fallback(uint64_t mask, T val, int laneMask) {
   return __shfl_xor_sync(mask, val, laneMask);
 }
 
-// Specializations for mctlass::half_t
 template <>
-TL_DEVICE half_t shfl_xor_sync(uint64_t mask, half_t val, int laneMask) {
+TL_DEVICE half_t shfl_xor_sync_fallback(uint64_t mask, half_t val,
+                                        int laneMask) {
   float f = static_cast<float>(val);
   float r = __shfl_xor_sync(mask, f, laneMask);
   return half_t(r);
@@ -417,6 +467,27 @@ TL_DEVICE uint1 shfl_xor_sync_fallback(uint64_t mask, uint1 val, int laneMask) {
   unsigned long raw = static_cast<unsigned long>(val.x);
   unsigned long result = __shfl_xor_sync(mask, raw, laneMask);
   return uint1(static_cast<unsigned int>(result));
+}
+
+template <typename T>
+TL_DEVICE T shfl_xor_sync(uint64_t mask, T val, int laneMask) {
+  if constexpr (sizeof(T) <= 2 * sizeof(uint32_t)) {
+    if (mask == uint64_t(-1)) {
+      switch (laneMask) {
+      case 1:
+        return shfl_xor_imm<1>(val);
+      case 2:
+        return shfl_xor_imm<2>(val);
+      case 4:
+        return shfl_xor_imm<4>(val);
+      case 8:
+        return shfl_xor_imm<8>(val);
+      default:
+        break;
+      }
+    }
+  }
+  return shfl_xor_sync_fallback(mask, val, laneMask);
 }
 
 } // namespace tl

--- a/src/tl_templates/maca/common.h
+++ b/src/tl_templates/maca/common.h
@@ -450,8 +450,7 @@ TL_DEVICE half_t extract_half_from_float16x2(float16x2 v, int lane) {
 }
 
 // Helper to extract bfloat16_t from bfloat16x2
-TL_DEVICE bfloat16_t extract_bfloat16_from_bfloat16x2(bfloat16x2 v,
-                                                    int lane) {
+TL_DEVICE bfloat16_t extract_bfloat16_from_bfloat16x2(bfloat16x2 v, int lane) {
   return v.data[lane];
 }
 

--- a/src/tl_templates/maca/common.h
+++ b/src/tl_templates/maca/common.h
@@ -439,7 +439,7 @@ template <typename T> TL_DEVICE ::uint1 to_uint1(T v) {
 //   3. half2           (FP16x2, MACA SDK __h*2 intrinsics)
 // =========================================================================
 // Pack two half_t into a uint1
-TL_DEVICE uint1 pack_half2(const half_t a, const half_t b) {
+TL_DEVICE uint1 pack_half2(half_t a, half_t b) {
   return __pack_half2(static_cast<__half>(a), static_cast<__half>(b));
 }
 
@@ -450,7 +450,7 @@ TL_DEVICE half_t extract_half_from_float16x2(float16x2 v, int lane) {
 }
 
 // Helper to extract bfloat16_t from bfloat16x2
-TL_DEVICE float16x2 extract_bfloat16_from_bfloat162(maca_bfloat162 v,
+TL_DEVICE bfloat16_t extract_bfloat16_from_bfloat16x2(bfloat16x2 v,
                                                     int lane) {
   return v.data[lane];
 }

--- a/src/tl_templates/maca/common.h
+++ b/src/tl_templates/maca/common.h
@@ -412,6 +412,13 @@ TL_DEVICE half_t shfl_xor_sync(uint64_t mask, half_t val, int laneMask) {
   return half_t(r);
 }
 
+template <>
+TL_DEVICE uint1 shfl_xor_sync_fallback(uint64_t mask, uint1 val, int laneMask) {
+  unsigned long raw = static_cast<unsigned long>(val.x);
+  unsigned long result = __shfl_xor_sync(mask, raw, laneMask);
+  return uint1(static_cast<unsigned int>(result));
+}
+
 } // namespace tl
 
 namespace tl {

--- a/src/tl_templates/maca/common.h
+++ b/src/tl_templates/maca/common.h
@@ -466,7 +466,7 @@ template <>
 TL_DEVICE uint1 shfl_xor_sync_fallback(uint64_t mask, uint1 val, int laneMask) {
   unsigned long raw = static_cast<unsigned long>(val.x);
   unsigned long result = __shfl_xor_sync(mask, raw, laneMask);
-  return uint1(static_cast<unsigned int>(result));
+  return uint1{static_cast<unsigned int>(result)};
 }
 
 template <typename T>

--- a/src/tl_templates/maca/common.h
+++ b/src/tl_templates/maca/common.h
@@ -157,44 +157,42 @@ template <> struct numeric_limits<maca_bfloat16> {
   static int const digits = 7;
 
   /// Least positive value
-  __device__ static mctlass::bfloat16_t min() {
-    return mctlass::bfloat16_t::bitcast(0x01);
+  __device__ static maca_bfloat16 min() {
+    return maca_bfloat16(__maca_bfloat16_raw{0x01});
   }
 
   /// Minimum finite value
-  __device__ static mctlass::bfloat16_t lowest() {
-    return mctlass::bfloat16_t::bitcast(0xff7f);
+  __device__ static maca_bfloat16 lowest() {
+    return maca_bfloat16(__maca_bfloat16_raw{0xff7f});
   }
 
   /// Maximum finite value
-  __device__ static mctlass::bfloat16_t max() {
-    return mctlass::bfloat16_t::bitcast(0x7f7f);
+  __device__ static maca_bfloat16 max() {
+    return maca_bfloat16(__maca_bfloat16_raw{0x7f7f});
   }
 
   /// Returns smallest finite value
-  __device__ static mctlass::bfloat16_t epsilon() {
-    return mctlass::bfloat16_t::bitcast(0x1000);
+  __device__ static maca_bfloat16 epsilon() {
+    return maca_bfloat16(__maca_bfloat16_raw{0x1000});
   }
 
   /// Returns maximum rounding error
-  __device__ static mctlass::bfloat16_t round_error() {
-    return mctlass::bfloat16_t(0.5f);
-  }
+  __device__ static maca_bfloat16 round_error() { return maca_bfloat16(0.5f); }
   /// Returns positive infinity value
-  __device__ static mctlass::bfloat16_t infinity() {
-    return mctlass::bfloat16_t::bitcast(0x7f80);
+  __device__ static maca_bfloat16 infinity() {
+    return maca_bfloat16(__maca_bfloat16_raw{0x7f80});
   }
   /// Returns quiet NaN value
-  __device__ static mctlass::bfloat16_t quiet_NaN() {
-    return mctlass::bfloat16_t::bitcast(0x7fff);
+  __device__ static maca_bfloat16 quiet_NaN() {
+    return maca_bfloat16(__maca_bfloat16_raw{0x7fff});
   }
   /// Returns signaling NaN value
-  __device__ static mctlass::bfloat16_t signaling_NaN() {
-    return mctlass::bfloat16_t::bitcast(0x7fff);
+  __device__ static maca_bfloat16 signaling_NaN() {
+    return maca_bfloat16(__maca_bfloat16_raw{0x7fff});
   }
   /// Returns smallest positive subnormal value
-  __device__ static mctlass::bfloat16_t denorm_min() {
-    return mctlass::bfloat16_t::bitcast(0x1);
+  __device__ static maca_bfloat16 denorm_min() {
+    return maca_bfloat16(__maca_bfloat16_raw{0x1});
   }
 };
 } // namespace platform
@@ -313,11 +311,19 @@ template <typename T> TL_DEVICE void AtomicAdd(_Float16 *address, T val) {
 }
 
 TL_DEVICE half_t max(const half_t a, const half_t b) {
-  return mctlass::fast_max(a, b);
+  return half_t(__hmax(a, b));
 }
 
 TL_DEVICE half_t min(const half_t a, const half_t b) {
-  return mctlass::fast_min(a, b);
+  return half_t(__hmin(a, b));
+}
+
+TL_DEVICE bfloat16_t max(const bfloat16_t a, const bfloat16_t b) {
+  return __hmax(a, b);
+}
+
+TL_DEVICE bfloat16_t min(const bfloat16_t a, const bfloat16_t b) {
+  return __hmin(a, b);
 }
 
 // DP4A
@@ -432,6 +438,22 @@ template <typename T> TL_DEVICE ::uint1 to_uint1(T v) {
 //   2. maca_bfloat162  (BF16x2, MACA SDK __h*2 intrinsics)
 //   3. half2           (FP16x2, MACA SDK __h*2 intrinsics)
 // =========================================================================
+// Pack two half_t into a uint1
+TL_DEVICE uint1 pack_half2(const half_t a, const half_t b) {
+  return __pack_half2(static_cast<__half>(a), static_cast<__half>(b));
+}
+
+// Helper to extract half_t from float16x2 (which uses _Float16)
+TL_DEVICE half_t extract_half_from_float16x2(float16x2 v, int lane) {
+  // float16x2 is a vector of _Float16, convert to half_t via float
+  return half_t(static_cast<float>(v[lane]));
+}
+
+// Helper to extract bfloat16_t from bfloat16x2
+TL_DEVICE float16x2 extract_bfloat16_from_bfloat162(maca_bfloat162 v,
+                                                    int lane) {
+  return v.data[lane];
+}
 
 // --- add2 ----------------------------------------------------------------
 

--- a/src/tl_templates/maca/reduce.h
+++ b/src/tl_templates/maca/reduce.h
@@ -69,43 +69,43 @@ struct MinOpNan {
 
 struct SumOp_bf16x2 {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
-    return tl::to_uint1(
-        tl::add2(tl::from_uint1<bfloat16x2>(x), tl::from_uint1<bfloat16x2>(y)));
+    return tl::to_uint1(tl::add2(tl::from_uint1<maca_bfloat162>(x),
+                                 tl::from_uint1<maca_bfloat162>(y)));
   }
 };
 
 struct MaxOp_bf16x2 {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
-    return tl::to_uint1(
-        tl::max2(tl::from_uint1<bfloat16x2>(x), tl::from_uint1<bfloat16x2>(y)));
+    return tl::to_uint1(tl::max2(tl::from_uint1<maca_bfloat162>(x),
+                                 tl::from_uint1<maca_bfloat162>(y)));
   }
 };
 
 struct MinOp_bf16x2 {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
-    return tl::to_uint1(
-        tl::min2(tl::from_uint1<bfloat16x2>(x), tl::from_uint1<bfloat16x2>(y)));
+    return tl::to_uint1(tl::min2(tl::from_uint1<maca_bfloat162>(x),
+                                 tl::from_uint1<maca_bfloat162>(y)));
   }
 };
 
 struct SumOp_fp16x2 {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
     return tl::to_uint1(
-        tl::add2(tl::from_uint1<float16x2>(x), tl::from_uint1<float16x2>(y)));
+        tl::add2(tl::from_uint1<half2>(x), tl::from_uint1<half2>(y)));
   }
 };
 
 struct MaxOp_fp16x2 {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
     return tl::to_uint1(
-        tl::max2(tl::from_uint1<float16x2>(x), tl::from_uint1<float16x2>(y)));
+        tl::max2(tl::from_uint1<half2>(x), tl::from_uint1<half2>(y)));
   }
 };
 
 struct MinOp_fp16x2 {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
     return tl::to_uint1(
-        tl::min2(tl::from_uint1<float16x2>(x), tl::from_uint1<float16x2>(y)));
+        tl::min2(tl::from_uint1<half2>(x), tl::from_uint1<half2>(y)));
   }
 };
 

--- a/src/tl_templates/maca/reduce.h
+++ b/src/tl_templates/maca/reduce.h
@@ -36,7 +36,7 @@ struct MinOp {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) {
     return min(x, y);
   }
-};
+}; 
 
 struct MaxOpNan {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) {
@@ -47,7 +47,7 @@ struct MaxOpNan {
     return __hmax_nan(x, y);
   }
   TL_DEVICE half_t operator()(half_t const &x, half_t const &y) const {
-    return __hmax_nan(x, y);
+    return half_t(__hmax_nan(x, y));
   }
 };
 
@@ -60,7 +60,7 @@ struct MinOpNan {
     return __hmin_nan(x, y);
   }
   TL_DEVICE half_t operator()(half_t const &x, half_t const &y) const {
-    return __hmin_nan(x, y);
+    return half_t(__hmin_nan(x, y));
   }
 };
 
@@ -91,21 +91,21 @@ struct MinOp_bf16x2 {
 struct SumOp_fp16x2 {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
     return tl::to_uint1(
-        tl::add2(tl::from_uint1<halfx2>(x), tl::from_uint1<halfx2>(y)));
+        tl::add2(tl::from_uint1<float16x2>(x), tl::from_uint1<float16x2>(y)));
   }
 };
 
 struct MaxOp_fp16x2 {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
     return tl::to_uint1(
-        tl::max2(tl::from_uint1<halfx2>(x), tl::from_uint1<halfx2>(y)));
+        tl::max2(tl::from_uint1<float16x2>(x), tl::from_uint1<float16x2>(y)));
   }
 };
 
 struct MinOp_fp16x2 {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
     return tl::to_uint1(
-        tl::min2(tl::from_uint1<halfx2>(x), tl::from_uint1<halfx2>(y)));
+        tl::min2(tl::from_uint1<float16x2>(x), tl::from_uint1<float16x2>(y)));
   }
 };
 
@@ -126,14 +126,14 @@ struct MinOpNan_bf16x2 {
 struct MaxOpNan_fp16x2 {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
     return tl::to_uint1(
-        tl::max2_nan(tl::from_uint1<halfx2>(x), tl::from_uint1<halfx2>(y)));
+        tl::max2_nan(tl::from_uint1<float16x2>(x), tl::from_uint1<float16x2>(y)));
   }
 };
 
 struct MinOpNan_fp16x2 {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
     return tl::to_uint1(
-        tl::min2_nan(tl::from_uint1<halfx2>(x), tl::from_uint1<halfx2>(y)));
+        tl::min2_nan(tl::from_uint1<float16x2>(x), tl::from_uint1<float16x2>(y)));
   }
 };
 

--- a/src/tl_templates/maca/reduce.h
+++ b/src/tl_templates/maca/reduce.h
@@ -36,7 +36,7 @@ struct MinOp {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) {
     return min(x, y);
   }
-}; 
+};
 
 struct MaxOpNan {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) {
@@ -125,15 +125,15 @@ struct MinOpNan_bf16x2 {
 
 struct MaxOpNan_fp16x2 {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
-    return tl::to_uint1(
-        tl::max2_nan(tl::from_uint1<float16x2>(x), tl::from_uint1<float16x2>(y)));
+    return tl::to_uint1(tl::max2_nan(tl::from_uint1<float16x2>(x),
+                                     tl::from_uint1<float16x2>(y)));
   }
 };
 
 struct MinOpNan_fp16x2 {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
-    return tl::to_uint1(
-        tl::min2_nan(tl::from_uint1<float16x2>(x), tl::from_uint1<float16x2>(y)));
+    return tl::to_uint1(tl::min2_nan(tl::from_uint1<float16x2>(x),
+                                     tl::from_uint1<float16x2>(y)));
   }
 };
 

--- a/src/tl_templates/maca/reduce.h
+++ b/src/tl_templates/maca/reduce.h
@@ -28,13 +28,112 @@ struct SumOp {
 
 struct MaxOp {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) {
-    return mctlass::fast_max(x, y);
+    return max(x, y);
   }
 };
 
 struct MinOp {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) {
-    return mctlass::fast_min(x, y);
+    return min(x, y);
+  }
+};
+
+struct MaxOpNan {
+  template <typename T> TL_DEVICE T operator()(T const &x, T const &y) {
+    return max(x, y);
+  }
+  TL_DEVICE bfloat16_t operator()(bfloat16_t const &x,
+                                  bfloat16_t const &y) const {
+    return __hmax_nan(x, y);
+  }
+  TL_DEVICE half_t operator()(half_t const &x, half_t const &y) const {
+    return __hmax_nan(x, y);
+  }
+};
+
+struct MinOpNan {
+  template <typename T> TL_DEVICE T operator()(T const &x, T const &y) {
+    return min(x, y);
+  }
+  TL_DEVICE bfloat16_t operator()(bfloat16_t const &x,
+                                  bfloat16_t const &y) const {
+    return __hmin_nan(x, y);
+  }
+  TL_DEVICE half_t operator()(half_t const &x, half_t const &y) const {
+    return __hmin_nan(x, y);
+  }
+};
+
+// Packed x2 reduce operators for bf16x2 and fp16x2
+// These operate on uint1 (packed 32-bit) values
+
+struct SumOp_bf16x2 {
+  template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
+    return tl::to_uint1(
+        tl::add2(tl::from_uint1<bfloat16x2>(x), tl::from_uint1<bfloat16x2>(y)));
+  }
+};
+
+struct MaxOp_bf16x2 {
+  template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
+    return tl::to_uint1(
+        tl::max2(tl::from_uint1<bfloat16x2>(x), tl::from_uint1<bfloat16x2>(y)));
+  }
+};
+
+struct MinOp_bf16x2 {
+  template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
+    return tl::to_uint1(
+        tl::min2(tl::from_uint1<bfloat16x2>(x), tl::from_uint1<bfloat16x2>(y)));
+  }
+};
+
+struct SumOp_fp16x2 {
+  template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
+    return tl::to_uint1(
+        tl::add2(tl::from_uint1<halfx2>(x), tl::from_uint1<halfx2>(y)));
+  }
+};
+
+struct MaxOp_fp16x2 {
+  template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
+    return tl::to_uint1(
+        tl::max2(tl::from_uint1<halfx2>(x), tl::from_uint1<halfx2>(y)));
+  }
+};
+
+struct MinOp_fp16x2 {
+  template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
+    return tl::to_uint1(
+        tl::min2(tl::from_uint1<halfx2>(x), tl::from_uint1<halfx2>(y)));
+  }
+};
+
+struct MaxOpNan_bf16x2 {
+  template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
+    return tl::to_uint1(tl::max2_nan(tl::from_uint1<bfloat16x2>(x),
+                                     tl::from_uint1<bfloat16x2>(y)));
+  }
+};
+
+struct MinOpNan_bf16x2 {
+  template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
+    return tl::to_uint1(tl::min2_nan(tl::from_uint1<bfloat16x2>(x),
+                                     tl::from_uint1<bfloat16x2>(y)));
+  }
+};
+
+struct MaxOpNan_fp16x2 {
+  template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
+    return tl::to_uint1(
+        tl::max2_nan(tl::from_uint1<halfx2>(x), tl::from_uint1<halfx2>(y)));
+  }
+};
+
+struct MinOpNan_fp16x2 {
+  template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
+    return tl::to_uint1(
+        tl::min2_nan(tl::from_uint1<halfx2>(x), tl::from_uint1<halfx2>(y)));
   }
 };
 

--- a/src/tl_templates/maca/reduce.h
+++ b/src/tl_templates/maca/reduce.h
@@ -42,11 +42,10 @@ struct MaxOpNan {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) {
     return max(x, y);
   }
-  TL_DEVICE bfloat16_t operator()(bfloat16_t const &x,
-                                  bfloat16_t const &y) const {
+  TL_DEVICE bfloat16_t operator()(bfloat16_t const &x, bfloat16_t const &y) {
     return __hmax_nan(x, y);
   }
-  TL_DEVICE half_t operator()(half_t const &x, half_t const &y) const {
+  TL_DEVICE half_t operator()(half_t const &x, half_t const &y) {
     return half_t(__hmax_nan(x, y));
   }
 };
@@ -55,11 +54,10 @@ struct MinOpNan {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) {
     return min(x, y);
   }
-  TL_DEVICE bfloat16_t operator()(bfloat16_t const &x,
-                                  bfloat16_t const &y) const {
+  TL_DEVICE bfloat16_t operator()(bfloat16_t const &x, bfloat16_t const &y) {
     return __hmin_nan(x, y);
   }
-  TL_DEVICE half_t operator()(half_t const &x, half_t const &y) const {
+  TL_DEVICE half_t operator()(half_t const &x, half_t const &y) {
     return half_t(__hmin_nan(x, y));
   }
 };

--- a/testing/python/language/test_tilelang_language_reduce.py
+++ b/testing/python/language/test_tilelang_language_reduce.py
@@ -96,7 +96,6 @@ REDUCE_CASES = [
 ]
 
 
-@tilelang.testing.pytest.mark.xfail
 @pytest.mark.parametrize(
     ("op", "dtype", "M", "N", "src_scope", "dst_scope", "threads", "batch"),
     REDUCE_CASES,

--- a/testing/python/language/test_tilelang_language_reduce.py
+++ b/testing/python/language/test_tilelang_language_reduce.py
@@ -373,9 +373,7 @@ def _make_nan_reduce_kernel(reduce_fn, M, N, dtype, threads, *, nan_propagate):
     return kernel
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_ge(8, 9)
 def test_reduce_packed_fp8_to_float16_absmax_runtime():
     if not hasattr(torch, "float8_e4m3fn"):
         pytest.skip("torch.float8_e4m3fn is not available")
@@ -404,7 +402,6 @@ def test_reduce_packed_fp8_to_float16_absmax_runtime():
     torch.testing.assert_close(B, ref, atol=0, rtol=0)
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_reduce_packed_max_nan_propagate_uses_nan_intrinsics():
     k = _compile(_make_nan_reduce_kernel(T.reduce_max, 128, 128, T.float16, threads=256, nan_propagate=True))
@@ -413,7 +410,6 @@ def test_reduce_packed_max_nan_propagate_uses_nan_intrinsics():
     assert "tl::MaxOpNan" in src
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_reduce_packed_min_nan_propagate_uses_nan_intrinsics():
     k = _compile(_make_nan_reduce_kernel(T.reduce_min, 128, 128, T.bfloat16, threads=256, nan_propagate=True))
@@ -422,7 +418,6 @@ def test_reduce_packed_min_nan_propagate_uses_nan_intrinsics():
     assert "tl::MinOpNan" in src
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_reduce_packed_absmax_nan_propagate_uses_nan_intrinsics():
     k = _compile(_make_nan_reduce_kernel(T.reduce_absmax, 128, 128, T.float16, threads=256, nan_propagate=True))
@@ -431,7 +426,6 @@ def test_reduce_packed_absmax_nan_propagate_uses_nan_intrinsics():
     assert "tl::MaxOpNan" in src
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_reduce_packed_max_nan_propagate_runtime():
     import math
@@ -445,7 +439,6 @@ def test_reduce_packed_max_nan_propagate_runtime():
         assert math.isnan(B[0].float().item()), f"{tl_dtype}: NaN row must produce NaN"
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_reduce_packed_min_nan_propagate_runtime():
     import math
@@ -459,7 +452,6 @@ def test_reduce_packed_min_nan_propagate_runtime():
         assert math.isnan(B[1].float().item()), f"{tl_dtype}: NaN row must produce NaN"
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_reduce_packed_max_nan_batch_runtime():
     import math

--- a/testing/python/language/test_tilelang_language_reduce_maxmin_nan.py
+++ b/testing/python/language/test_tilelang_language_reduce_maxmin_nan.py
@@ -43,7 +43,6 @@ def test_reduce_max_default_uses_plain_op():
     assert "__hmax(" in src and "__hmax_nan" not in src
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_reduce_max_nan_propagate_uses_nan_op():
     k = _compile(_make_reduce_kernel(T.reduce_max, 64, T.float16, nan_propagate=True))
@@ -52,7 +51,6 @@ def test_reduce_max_nan_propagate_uses_nan_op():
     assert "__hmax_nan" in src
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_reduce_min_nan_propagate_uses_nan_op():
     k = _compile(_make_reduce_kernel(T.reduce_min, 64, T.bfloat16, nan_propagate=True))
@@ -61,7 +59,6 @@ def test_reduce_min_nan_propagate_uses_nan_op():
     assert "__hmin_nan" in src
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_reduce_absmax_nan_propagate_uses_nan_op():
     k = _compile(_make_reduce_kernel(T.reduce_absmax, 64, T.float16, nan_propagate=True))
@@ -75,7 +72,6 @@ def test_reduce_absmax_nan_propagate_uses_nan_op():
 # ---------------------------------------------------------------------------
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_reduce_max_runtime_nan_behavior():
     for _, tl_dtype, torch_dtype in _DTYPES:
@@ -93,7 +89,6 @@ def test_reduce_max_runtime_nan_behavior():
         assert math.isnan(out_nan.float().item()), f"{tl_dtype}: nan_propagate reduce_max should return NaN, got {out_nan}"
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_reduce_min_runtime_nan_behavior():
     for _, tl_dtype, torch_dtype in _DTYPES:


### PR DESCRIPTION
fix test_tilelang_language_reduce.py nan xfail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Fixed NaN-aware min/max reduction handling for scalar `half`/`bfloat16` by adding explicit `tl::max_nan()` / `tl::min_nan()` lowering in MACA codegen (`__hmax_nan` / `__hmin_nan`) and introducing corresponding `MaxOpNan` / `MinOpNan` reducers.
- Updated generic min/max reduction functors in `reduce.h` to use `min`/`max` (instead of `mctlass::fast_min`/`fast_max`) and added NaN-aware packed `x2` reduction operators for `fp16x2`/`bf16x2` (`max2_nan`/`min2_nan`).
- Extended MACA codegen for packed half/bfloat16 handling: use `tl::pack_half2` for `float16x2` construction and improved lane extraction for `bfloat16x2`/`float16x2` to select the correct scalar lane.
- Updated MACA template utilities in `common.h` (numeric limits bit-pattern construction, half2 pack/extract helpers, and `shfl_xor_sync` refactor with an advisory fallback path).
- Adjusted `test_tilelang_language_reduce.py` to remove `xfail` expectations for the previously failing reduce/packed-reduce NaN cases and relaxed the FP8→float16 absmax gating to broader CUDA availability.

## C++ style / lint notes
- This PR modifies C++ sources under `src/` (including TileLang-owned MACA headers). It does **not** change any rules in `docs/developer_guide/cpp_style.md`.
- The changes are template-heavy and may trigger the “C++ API style audit (warning only)” CI step (e.g., naming/visibility/template-boundary heuristics). Treat any TLCPP003/TLCPP004 findings as advisory unless they indicate a clear maintainability/FFI/API risk introduced by this PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->