### PR TITLE
[MetaxGPU][testing] fix some xfail case in language, issue

### DIFF
--- a/src/maca/codegen/codegen_maca.cc
+++ b/src/maca/codegen/codegen_maca.cc
@@ -1419,12 +1419,21 @@ void CodeGenTileLangMACA::VisitExpr_(const CastNode *op, std::ostream &os) {
   }
 
   // Fallback: elementwise cast
+  // fp16<->bf16 elements load as native __half/bfloat16, where a direct
+  // `(bfloat16_t)(__half)` (or reverse) is an ambiguous conversion; route
+  // through float to disambiguate.
+  bool cross_half = (from_ty.is_float16() && target_ty.is_bfloat16()) ||
+                    (from_ty.is_bfloat16() && target_ty.is_float16());
   for (int i = 0, lanes = from_ty.lanes(); i < lanes; ++i) {
     std::ostringstream val;
     val << "(";
     PrintType(target_ty.element_of(), val);
     val << ")(";
+    if (cross_half)
+      val << "(float)(";
     PrintVecElemLoad(src, from_ty, i, val);
+    if (cross_half)
+      val << ")";
     val << ")";
     PrintVecElemStore(sret, target_ty, i, val.str());
   }
@@ -2647,8 +2656,19 @@ void CodeGenTileLangMACA::VisitExpr_(const BufferLoadNode *op,
   int lanes = op->dtype.lanes();
   // declare type.
   if (value_dtype.lanes() == element_dtype.lanes()) {
-    std::string ref = GetBufferRef(op->dtype, op->buffer.get(), index);
-    HandleVolatileLoads(ref, op, os);
+    // For scalar fp4 loads from non-packed buffers, use tl_fp4_packed_load
+    // to correctly extract the nibble at the given index (the /2 in
+    // GetBufferRef maps two consecutive fp4 elements to the same byte, but
+    // reading that byte only returns the low nibble — the odd-indexed element
+    // is lost).
+    if (element_dtype.is_float4() && element_dtype.lanes() == 1) {
+      std::string idx_str = PrintExpr(index);
+      std::string vid = GetVarID(buffer_var.get());
+      os << "tl_fp4_packed_load((fp4_e2_2_t*)" << vid << ", " << idx_str << ")";
+    } else {
+      std::string ref = GetBufferRef(op->dtype, op->buffer.get(), index);
+      HandleVolatileLoads(ref, op, os);
+    }
   } else {
     bool can_vector_load = false;
     arith::PVar<PrimExpr> base;
@@ -2709,11 +2729,24 @@ void CodeGenTileLangMACA::VisitStmt_(const BufferStoreNode *op) {
   Var buffer_var = op->buffer->data;
 
   if (value_dtype.lanes() == element_dtype.lanes()) {
-    std::string value = this->PrintExpr(op->value);
-    std::string ref =
-        this->GetBufferRef(value_dtype, op->buffer.get(), index_expr);
-    this->PrintIndent();
-    stream << ref << " = " << value << ";\n";
+    // For scalar fp4 stores to non-packed buffers, use tl_fp4_packed_store
+    // to correctly handle nibble-level writes. The /2 in GetBufferRef maps two
+    // consecutive fp4 elements to the same byte, and a plain assignment
+    // overwrites the entire byte — destroying the neighboring nibble.
+    if (element_dtype.is_float4() && element_dtype.lanes() == 1) {
+      std::string idx_str = PrintExpr(index_expr);
+      std::string value = this->PrintExpr(op->value);
+      std::string vid = GetVarID(buffer_var.get());
+      this->PrintIndent();
+      stream << "tl_fp4_packed_store((fp4_e2_2_t*)" << vid << ", " << idx_str
+             << ", " << value << ");\n";
+    } else {
+      std::string value = this->PrintExpr(op->value);
+      std::string ref =
+          this->GetBufferRef(value_dtype, op->buffer.get(), index_expr);
+      this->PrintIndent();
+      stream << ref << " = " << value << ";\n";
+    }
   } else {
     arith::PVar<PrimExpr> base;
     int ramp_lanes = value_dtype.lanes() / element_dtype.lanes();

--- a/src/maca/codegen/intrin_rule_maca.cc
+++ b/src/maca/codegen/intrin_rule_maca.cc
@@ -137,6 +137,21 @@ static PrimExpr DispatchMACAWarpActiveMask(const PrimExpr &e) {
   return Call(call->dtype, Op::Get("tirx.maca.__activemask"), call->args);
 }
 
+static PrimExpr DispatchMACAIsFinite(const PrimExpr &e) {
+  const CallNode *call = e.as<CallNode>();
+  ICHECK(call != nullptr);
+  ICHECK_EQ(call->args.size(), 1U);
+
+  DataType arg_dtype = call->args[0].dtype();
+  if (arg_dtype.is_float() &&
+      (arg_dtype.bits() == 32 || arg_dtype.bits() == 64)) {
+    ffi::Array<PrimExpr> new_args = {StringImm("isfinite"), call->args[0]};
+    return Call(call->dtype, builtin::call_pure_extern(), new_args);
+  }
+
+  return e;
+}
+
 template <typename T> static PrimExpr DispatchMACAShuffle(const PrimExpr &e) {
   const CallNode *call = e.as<CallNode>();
   ICHECK(call != nullptr);
@@ -266,6 +281,9 @@ TVM_REGISTER_OP("tirx.fmod")
 TVM_REGISTER_OP("tirx.rsqrt")
     .set_attr<FLowerIntrinsic>("maca.FLowerIntrinsic",
                                DispatchPureExtern<MACAMath>);
+
+TVM_REGISTER_OP("tirx.isfinite")
+    .set_attr<FLowerIntrinsic>("maca.FLowerIntrinsic", DispatchMACAIsFinite);
 
 // Register low-level builtin ops.
 // TODO(tvm-team): consider make MACA its own subfolder and create a file for

--- a/testing/python/issue/test_tilelang_issue_1810.py
+++ b/testing/python/issue/test_tilelang_issue_1810.py
@@ -3,7 +3,6 @@ import tilelang.testing
 from tilelang import language as T
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_issue_1810_l2_persistent_float16_host_stub_no_half(monkeypatch):
     """Regression for issue #1810.
@@ -21,10 +20,10 @@ def test_issue_1810_l2_persistent_float16_host_stub_no_half(monkeypatch):
             T.annotate_l2_hit_ratio({A: 0.9})
             T.evaluate(0)
 
-    kernel = tilelang.compile(minimal_kernel, execution_backend="tvm_ffi")
+    kernel = tilelang.compile(minimal_kernel, execution_backend="tvm_ffi", target="auto")
     source = kernel.get_host_source()
-    assert "__tvm_cuda_stream_set_access_policy_window_packed" in source
-    assert "__tvm_cuda_stream_reset_access_policy_window_packed" in source
+    assert "__tvm_maca_stream_set_access_policy_window_packed" in source
+    assert "__tvm_maca_stream_reset_access_policy_window_packed" in source
     assert "half*" not in source
     assert "((half*)" not in source
 

--- a/testing/python/issue/test_tilelang_issue_2307.py
+++ b/testing/python/issue/test_tilelang_issue_2307.py
@@ -17,13 +17,12 @@ def _get_issue_2307_source() -> str:
                 if i < 16:
                     T.device_assert(T.isfinite(score_fragment[i]))
 
-    target = tilelang.backend.target.determine_target(return_object=True)
+    target = tilelang.backend.target.determine_target("auto", return_object=True)
     with target:
         artifact = tilelang.lower(main, target=target)
     return artifact.kernel_source
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_fragment_read_assert_parallel_loop_is_partitioned():
     src = _get_issue_2307_source()

--- a/testing/python/language/test_tilelang_language_copy.py
+++ b/testing/python/language/test_tilelang_language_copy.py
@@ -54,7 +54,6 @@ def run_tilelang_copy_cross_dtype(M=256, N=256, block_M=128, block_N=128, src_dt
     torch.testing.assert_close(b, a.to(getattr(torch, dst_dtype)), rtol=1e-2, atol=1e-2)
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_tilelang_copy_cross_dtype():
     run_tilelang_copy_cross_dtype(src_dtype=T.float16, dst_dtype=T.bfloat16)

--- a/testing/python/language/test_tilelang_language_subtype.py
+++ b/testing/python/language/test_tilelang_language_subtype.py
@@ -308,14 +308,13 @@ def test_subtype_complex_expressions_various(m, n):
 # ---------------------------------------------------------------------------
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize("block_size", [8, 16])
 def test_subtype_fp4_dynamic_stride_store(block_size):
     """fp4 store via StridedTensor: dynamic strides must match static strides."""
     num_blocks, n, padding = 10, 64, 4
     fp4_bytes = 64  # 128 fp4 elems packed into 64 bytes
-    jit_kw = dict(out_idx=None, target="cuda", pass_configs={"tl.disable_data_race_check": True})
+    jit_kw = dict(out_idx=None, target="auto", pass_configs={"tl.disable_data_race_check": True})
 
     def make_buf():
         row = fp4_bytes + padding
@@ -367,7 +366,6 @@ def test_subtype_fp4_dynamic_stride_store(block_size):
     )
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize("n", [64, 128])
 def test_subtype_fp4_scalar_store_codegen(n):

--- a/tilelang/language/print_op.py
+++ b/tilelang/language/print_op.py
@@ -122,9 +122,14 @@ def print_local_buffer_with_condition(condition: tirx.PrimExpr, buffer: tirx.Buf
 
 
 def device_assert(condition: tirx.PrimExpr, msg: str = "", no_stack_info=False):
-    from tilelang.cuda.debug import device_assert as cuda_device_assert
+    from tilelang.maca.target import check_maca_availability
 
-    return cuda_device_assert(condition, msg, no_stack_info)
+    if check_maca_availability():
+        from tilelang.maca.debug import device_assert as maca_device_assert
+        return maca_device_assert(condition, msg, no_stack_info)
+    else:
+        from tilelang.cuda.debug import device_assert as cuda_device_assert
+        return cuda_device_assert(condition, msg, no_stack_info)
 
 
 # NOTE(chaofan): T.print is implemented as a macro, so no return

--- a/tilelang/language/print_op.py
+++ b/tilelang/language/print_op.py
@@ -126,9 +126,11 @@ def device_assert(condition: tirx.PrimExpr, msg: str = "", no_stack_info=False):
 
     if check_maca_availability():
         from tilelang.maca.debug import device_assert as maca_device_assert
+
         return maca_device_assert(condition, msg, no_stack_info)
     else:
         from tilelang.cuda.debug import device_assert as cuda_device_assert
+
         return cuda_device_assert(condition, msg, no_stack_info)
 
 

--- a/tilelang/maca/debug.py
+++ b/tilelang/maca/debug.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import warnings
+
+from tvm import tirx
+
+import tilelang.language as T
+from tilelang.maca.target import check_maca_availability
+from tilelang.language.eager.builder import Builder, macro
+
+_IS_MACA_AVAILABLE = check_maca_availability()
+
+
+def get_stack_str(msg, stacklevel=1):
+    stack = Builder.current().get_fileline_stack(stacklevel)
+    msg = msg + "\n"
+    for fileline, lineno, macro_name in stack:
+        msg += f"  at {fileline}:{lineno} in {macro_name}\n"
+    return msg
+
+
+@macro
+def device_assert(condition: tirx.PrimExpr, msg: str = "", no_stack_info=False):
+    """
+    Device-side assert emulation for MACA targets.
+    """
+    if _IS_MACA_AVAILABLE:
+        if no_stack_info:
+            if msg == "":
+                T.call_intrin("void", tirx.op.Op.get("tl.device_assert"), condition)
+            else:
+                warnings.warn("Non-empty msg may slightly slow down the kernel", stacklevel=2)
+                T.call_intrin("void", tirx.op.Op.get("tl.device_assert_with_msg"), condition, msg)
+        else:
+            T.call_intrin("void", tirx.op.Op.get("tl.device_assert_with_msg"), condition, get_stack_str(msg, stacklevel=2))


### PR DESCRIPTION
 fix some xfail case in language, issue :
- testing/python/issue/test_tilelang_issue_1810.py
- testing/python/issue/test_tilelang_issue_2307.py
- testing/python/language/test_tilelang_language_copy.py
- testing/python/language/test_tilelang_language_subtype.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adjusted MACA backend handling and updated tests to unblock previously expected failures.

Key changes:
- Fixed MACA codegen for fp16/bf16 casts, scalar FP4 packed loads/stores, and nibble-safe FP4 buffer writes.
- Added MACA-aware `device_assert` dispatch so runtime assertions use MACA or CUDA backends as available.
- Introduced MACA debug assertion support with optional stack trace formatting and warning behavior when stack info is disabled.
- Updated several issue/language tests to use `target="auto"` and removed outdated `xfail` markers where the cases now pass.

C++ style / lint notes:
- The PR does not modify `docs/developer_guide/cpp_style.md`, but it does touch C++ implementation under `src/maca/codegen/` (`codegen_maca.cc`, `intrin_rule_maca.cc`).
- The CI step “C++ API Style Audit (warning only)” is present in `.github/workflows/ci.yml`; this PR appears implementation-focused (no public API/FFI surface changes called out), so it should not introduce new blocking style findings. Any TLCPP003/TLCPP004-type warnings would be advisory only, as per the existing warning-only CI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->