### PR TITLE
[MetaxGPU][testing] fix some xfail case in language

### DIFF
--- a/src/maca/codegen/codegen_maca.cc
+++ b/src/maca/codegen/codegen_maca.cc
@@ -2230,6 +2230,21 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
     os << "__shfl_up_sync(" << PrintExpr(op->args[0]) << ", "
        << PrintExpr(op->args[1]) << ", " << PrintExpr(op->args[2]) << ", "
        << PrintExpr(op->args[3]) << ")";
+  } else if (op->op.same_as(tl::match_any_sync())) {
+    ICHECK_EQ(op->args.size(), 2U)
+        << "tl.match_any_sync expects <mask, value>.";
+    os << "__match_any_sync(" << PrintExpr(op->args[0]) << ", "
+       << PrintExpr(op->args[1]) << ")";
+  } else if (op->op.same_as(tl::match_all_sync())) {
+    ICHECK_EQ(op->args.size(), 2U)
+        << "tl.match_all_sync expects <mask, value>.";
+    // __match_all_sync writes a `pred` flag through its third argument. We
+    // hide the out-parameter behind an immediately-invoked lambda and
+    // discard pred (the returned mask already encodes whether all lanes
+    // agreed: a non-zero result implies pred == 1).
+    os << "([&]() -> unsigned { int _tl_pred = 0; return __match_all_sync("
+       << PrintExpr(op->args[0]) << ", " << PrintExpr(op->args[1])
+       << ", &_tl_pred); }())";
   } else if (op->op.same_as(tl::get_lane_idx())) {
     ICHECK_LE(op->args.size(), 1)
         << "tl.get_lane_idx expects at most one argument <warp_size>.";
@@ -2359,6 +2374,16 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
     // Emit __ldg(&buffer_ref)
     auto buffer_ref = this->GetBufferRef(op->dtype, buffer, base);
     os << "__ldg(&(" << buffer_ref << "))";
+  } else if (op->op.same_as(tl::__ffs())) {
+    ICHECK_EQ(op->args.size(), 1U) << "T.__ffs expects one argument.";
+    DataType arg_dtype = op->args[0].dtype();
+    ICHECK(arg_dtype.is_int() || arg_dtype.is_uint())
+        << "T.__ffs expects an integer argument, but got " << arg_dtype;
+    ICHECK(arg_dtype.bits() == 32 || arg_dtype.bits() == 64)
+        << "T.__ffs expects a 32-bit or 64-bit integer argument, but got "
+        << arg_dtype;
+    os << (arg_dtype.bits() == 64 ? "__ffsll(" : "__ffs(")
+       << PrintExpr(op->args[0]) << ")";
   } else if (op->op.same_as(tl::ldg32())) {
     // Explicit 32-bit global memory load: load_global_32(ptr) or
     // load_global_32_conditional(ptr, pred)

--- a/src/maca/codegen/codegen_maca.cc
+++ b/src/maca/codegen/codegen_maca.cc
@@ -2175,6 +2175,37 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
     enable_sparse_gemm_ = true;
     this->PrintCallExtern(GetType(tvm::ffi::GetRef<PrimExpr>(op)),
                           op_instance->value, op->args, true, os);
+  } else if (op->op.same_as(tl::any_sync())) {
+    ICHECK_EQ(op->args.size(), 2U) << "tl.any_sync expects <mask, predicate>.";
+    os << "__any_sync(" << PrintExpr(op->args[0]) << ", "
+       << PrintExpr(op->args[1]) << ")";
+  } else if (op->op.same_as(tl::all_sync())) {
+    ICHECK_EQ(op->args.size(), 2U) << "tl.all_sync expects <mask, predicate>.";
+    os << "__all_sync(" << PrintExpr(op->args[0]) << ", "
+       << PrintExpr(op->args[1]) << ")";
+  } else if (op->op.same_as(tl::ballot_sync())) {
+    ICHECK_EQ(op->args.size(), 2U)
+        << "tl.ballot_sync expects <mask, predicate>.";
+    // __ballot_sync returns unsigned int (32 bits); zero-extend to uint64.
+    os << "((unsigned long long)__ballot_sync(" << PrintExpr(op->args[0])
+       << ", " << PrintExpr(op->args[1]) << "))";
+  } else if (op->op.same_as(tl::ballot())) {
+    ICHECK_EQ(op->args.size(), 1U) << "tl.ballot expects <predicate>.";
+    os << "((unsigned long long)__ballot_sync(0xFFFFFFFFu, "
+       << PrintExpr(op->args[0]) << "))";
+  } else if (op->op.same_as(tl::activemask())) {
+    ICHECK(op->args.empty()) << "tl.activemask takes no arguments.";
+    os << "((unsigned long long)__activemask())";
+  } else if (op->op.same_as(tl::syncthreads_count())) {
+    ICHECK_EQ(op->args.size(), 1U)
+        << "tl.syncthreads_count expects <predicate>.";
+    os << "__syncthreads_count(" << PrintExpr(op->args[0]) << ")";
+  } else if (op->op.same_as(tl::syncthreads_and())) {
+    ICHECK_EQ(op->args.size(), 1U) << "tl.syncthreads_and expects <predicate>.";
+    os << "__syncthreads_and(" << PrintExpr(op->args[0]) << ")";
+  } else if (op->op.same_as(tl::syncthreads_or())) {
+    ICHECK_EQ(op->args.size(), 1U) << "tl.syncthreads_or expects <predicate>.";
+    os << "__syncthreads_or(" << PrintExpr(op->args[0]) << ")";
   } else if (op->op.same_as(tl::shfl_sync())) {
     ICHECK_EQ(op->args.size(), 4U)
         << "tl.shfl_sync expects <mask, value, src_lane, width>.";

--- a/src/tl_templates/maca/maca_fp8.h
+++ b/src/tl_templates/maca/maca_fp8.h
@@ -233,6 +233,10 @@ public:
   }
 };
 
+TL_DEVICE unsigned char __tl_cvt_float_to_e8m0(const float src);
+TL_DEVICE unsigned char __tl_cvt_double_to_e8m0(const double src);
+TL_DEVICE unsigned char __tl_cvt_int_to_e8m0(const int src);
+
 struct fp8_e8_t {
   using value_t = unsigned char;
   value_t v;
@@ -241,6 +245,10 @@ struct fp8_e8_t {
 
   // construct from underlying storage
   TL_DEVICE explicit fp8_e8_t(value_t x) : v(x) {}
+
+  TL_DEVICE explicit fp8_e8_t(int x) : v(__tl_cvt_int_to_e8m0(x)) {}
+  TL_DEVICE explicit fp8_e8_t(float x) : v(__tl_cvt_float_to_e8m0(x)) {}
+  TL_DEVICE explicit fp8_e8_t(double x) : v(__tl_cvt_double_to_e8m0(x)) {}
 
   // allow construction from types that can initialize the storage (e.g. int)
   template <class T,
@@ -639,6 +647,15 @@ __tl_cvt_e8m0x2_to_bfloat162(const __maca_fp8x2_storage_t src) {
   float f_lo = __tl_cvt_e8m0_to_float(lo);
   float f_hi = __tl_cvt_e8m0_to_float(hi);
   return __floats2bfloat162_rn(f_lo, f_hi);
+}
+
+// int8 -> e8m0
+TL_DEVICE unsigned char __tl_cvt_int8_to_e8m0(const int8_t src) {
+  if (src == 0) {
+    return 0U;
+  }
+  const float f_val = static_cast<float>(src > 0 ? src : -src);
+  return __tl_cvt_float_to_e8m0(f_val);
 }
 
 // float -> e8m0

--- a/src/tl_templates/maca/maca_fp8.h
+++ b/src/tl_templates/maca/maca_fp8.h
@@ -658,6 +658,15 @@ TL_DEVICE unsigned char __tl_cvt_int8_to_e8m0(const int8_t src) {
   return __tl_cvt_float_to_e8m0(f_val);
 }
 
+// int -> e8m0
+TL_DEVICE unsigned char __tl_cvt_int_to_e8m0(const int src) {
+  if (src == 0) {
+    return 0U;
+  }
+  const float f_val = static_cast<float>(src > 0 ? src : -src);
+  return __tl_cvt_float_to_e8m0(f_val);
+}
+
 // float -> e8m0
 TL_DEVICE unsigned char __tl_cvt_float_to_e8m0(const float src) {
   unsigned int bits = *reinterpret_cast<const unsigned int *>(&src);

--- a/testing/python/language/test_tilelang_language_sync_threads.py
+++ b/testing/python/language/test_tilelang_language_sync_threads.py
@@ -11,7 +11,6 @@ def _compile_cuda(func):
         tilelang.enable_cache()
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_sync_threads_with_variable_barrier_id():
     @T.prim_func
@@ -23,7 +22,7 @@ def test_sync_threads_with_variable_barrier_id():
 
     kernel = _compile_cuda(kernel)
     src = kernel.get_kernel_source()
-    assert "tl::__sync_thread_partial(" in src, src
+    assert "tl::__sync_thread_partial<" in src, src
 
 
 @tilelang.testing.pytest.mark.skip

--- a/testing/python/language/test_tilelang_language_warp_vote.py
+++ b/testing/python/language/test_tilelang_language_warp_vote.py
@@ -40,7 +40,6 @@ def kernel_any_sync():
     return main
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_any_sync():
     b = torch.zeros((32,), device="cuda", dtype=torch.int32)
@@ -73,7 +72,6 @@ def kernel_all_sync():
     return main
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_all_sync():
     b = torch.zeros((32,), device="cuda", dtype=torch.int32)
@@ -105,7 +103,6 @@ def kernel_ballot_sync():
     return main
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_ballot_sync():
     b = torch.zeros((32,), device="cuda", dtype=torch.int64)
@@ -140,7 +137,6 @@ def kernel_ballot():
     return main
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_ballot():
     b = torch.zeros((32,), device="cuda", dtype=torch.int64)
@@ -175,7 +171,6 @@ def kernel_ffs_ballot_sync():
     return main
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_ffs_ballot_sync():
     b = torch.zeros((32,), device="cuda", dtype=torch.int32)
@@ -208,7 +203,6 @@ def kernel_activemask():
     return main
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_activemask():
     b = torch.zeros((32,), device="cuda", dtype=torch.int64)
@@ -242,7 +236,6 @@ def kernel_syncthreads_count():
     return main
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_syncthreads_count():
     b = torch.zeros((32,), device="cuda", dtype=torch.int32)
@@ -290,7 +283,6 @@ def kernel_syncthreads_and_false():
     return main
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_syncthreads_and():
     b = torch.zeros((32,), device="cuda", dtype=torch.int32)
@@ -343,7 +335,6 @@ def kernel_syncthreads_or_false():
     return main
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_syncthreads_or():
     b = torch.zeros((32,), device="cuda", dtype=torch.int32)
@@ -383,7 +374,6 @@ def kernel_match_any_sync():
     return main
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_match_any_sync():
     b = torch.zeros((32,), device="cuda", dtype=torch.int32)
@@ -435,7 +425,6 @@ def kernel_match_all_sync_false():
     return main
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_match_all_sync():
     b = torch.zeros((32,), device="cuda", dtype=torch.int32)


### PR DESCRIPTION
fix some xfail case in language:
- testing/python/language/test_tilelang_language_sync_threads.py
- testing/python/language/test_tilelang_language_warp_vote.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Expanded MACA codegen to lower additional `tl::` synchronization and warp-vote intrinsics, including `any_sync`, `all_sync`, `ballot_sync`, `ballot`, `activemask`, and `syncthreads_*`.
- Added `fp8_e8_t` conversions from `int`, `float`, and `double`, plus supporting conversion helpers in the MACA FP8 header.
- Updated language tests by removing several `xfail` markers and aligning one sync-thread expectation with the generated C++ form.

## C++ style / lint notes
- This PR touches `src/maca/codegen/codegen_maca.cc` and `src/tl_templates/maca/maca_fp8.h`, which are covered by `docs/developer_guide/cpp_style.md`.
- The `C++ API Style Audit (warning only)` CI step is relevant because this PR introduces/extends C++ surface area in the public header (`fp8_e8_t` constructor overloads and additional conversion helpers). Any TLCPP003/TLCPP004 findings should be reviewed as advisory unless they indicate an actual API/maintainability/FFI risk introduced by these new declarations.
- Changes are functional codegen/header additions and test un-hiding (not style-only); no separate formatting/namespace cleanup is indicated by the diff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->