### PR TITLE
[MetaxGPU][examples] fix some examples

### DIFF
--- a/examples/deepseek_mla/example_mla_decode.py
+++ b/examples/deepseek_mla/example_mla_decode.py
@@ -226,8 +226,8 @@ def main(
     qk_flops = 2 * batch * heads * kv_ctx * (dim + pe_dim)
     pv_flops = 2 * batch * heads * kv_ctx * dim
     total_flops = qk_flops + pv_flops
-    BLOCK_N = 64
-    BLOCK_H = min(64, heads // kv_heads)
+    BLOCK_N = 32
+    BLOCK_H = min(16, heads // kv_heads)
     num_split = 1
     softmax_scale = (dim + pe_dim) ** -0.5
 

--- a/examples/deepseek_mla/example_mla_decode.py
+++ b/examples/deepseek_mla/example_mla_decode.py
@@ -254,7 +254,7 @@ def run_regression_perf(
 
     kernel = flashattn(batch, heads, kv_heads, kv_ctx, dim, pe_dim, BLOCK_N, BLOCK_H, num_split, softmax_scale)
     profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Randn)
-    profiler.assert_allclose(ref_program, rtol=1e-4, atol=1e-4)
+    profiler.assert_allclose(ref_program, rtol=2e-4, atol=1e-4)
     return profiler.do_bench(backend="cupti")
 
 

--- a/examples/deepseek_mla/example_mla_decode.py
+++ b/examples/deepseek_mla/example_mla_decode.py
@@ -30,13 +30,12 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
         glse = T.alloc_global([batch, heads, num_split], dtype)
         Output_partial = T.alloc_global([batch, heads, num_split, dim], dtype)
         # flash_attn_split
-        with T.Kernel(batch, heads // min(block_H, kv_group_num), num_split, threads=256) as (bid, hid, bz):
+        with T.Kernel(batch, heads // min(block_H, kv_group_num), num_split, threads=128) as (bid, hid, bz):
             Q_shared = T.alloc_shared([block_H, dim], dtype)
             S_shared = T.alloc_shared([block_H, block_N], dtype)
             Q_pe_shared = T.alloc_shared([block_H, pe_dim], dtype)
             KV_shared = T.alloc_shared([block_N, dim], dtype)
             K_pe_shared = T.alloc_shared([block_N, pe_dim], dtype)
-            O_shared = T.alloc_shared([block_H, dim], dtype)
             acc_s = T.alloc_fragment([block_H, block_N], accum_dtype)
             acc_s_cast = T.alloc_fragment([block_H, block_N], dtype)
             acc_o = T.alloc_fragment([block_H, dim], accum_dtype)
@@ -56,7 +55,7 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
             T.fill(scores_max, -T.infinity(accum_dtype))
 
             loop_range = T.ceildiv((seqlen_kv // num_split), block_N)
-            for k in T.Pipelined(loop_range, num_stages=2):
+            for k in T.Pipelined(loop_range, num_stages=1):
                 kv_start = (seqlen_kv // num_split) * bz + k * block_N
                 kv_end = (seqlen_kv // num_split) * bz + (k + 1) * block_N
                 T.copy(KV[bid, kv_start:kv_end, cur_kv_head, :], KV_shared)
@@ -86,8 +85,7 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
             for i in T.Parallel(block_H):
                 logsum[i] = T.log2(logsum[i]) + scores_max[i] * scale
             T.copy(logsum, glse[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, bz])
-            T.copy(acc_o, O_shared)
-            T.copy(O_shared, Output_partial[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, bz, :])
+            T.copy(acc_o, Output_partial[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, bz, :])
 
         # combine
         with T.Kernel(heads, batch, threads=128) as (hid, bz):
@@ -125,13 +123,12 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
         K_pe: T.Tensor([batch, seqlen_kv, kv_head_num, pe_dim], dtype),
         Output: T.Tensor([batch, heads, dim], dtype),
     ):
-        with T.Kernel(heads // min(block_H, kv_group_num), batch, threads=256) as (hid, bid):
+        with T.Kernel(heads // min(block_H, kv_group_num), batch, threads=128) as (hid, bid):
             Q_shared = T.alloc_shared([block_H, dim], dtype)
             S_shared = T.alloc_shared([block_H, block_N], dtype)
             Q_pe_shared = T.alloc_shared([block_H, pe_dim], dtype)
             KV_shared = T.alloc_shared([block_N, dim], dtype)
             K_pe_shared = T.alloc_shared([block_N, pe_dim], dtype)
-            O_shared = T.alloc_shared([block_H, dim], dtype)
             acc_s = T.alloc_fragment([block_H, block_N], accum_dtype)
             acc_o = T.alloc_fragment([block_H, dim], accum_dtype)
             scores_max = T.alloc_fragment([block_H], accum_dtype)
@@ -149,7 +146,7 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
             T.fill(scores_max, -T.infinity(accum_dtype))
 
             loop_range = T.ceildiv(seqlen_kv, block_N)
-            for k in T.Pipelined(loop_range, num_stages=2):
+            for k in T.Pipelined(loop_range, num_stages=1):
                 T.copy(KV[bid, k * block_N : (k + 1) * block_N, cur_kv_head, :], KV_shared)
                 T.copy(K_pe[bid, k * block_N : (k + 1) * block_N, cur_kv_head, :], K_pe_shared)
                 T.gemm(Q_shared, KV_shared, acc_s, transpose_B=True, policy=T.GemmWarpPolicy.FullCol, clear_accum=True)
@@ -172,8 +169,7 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
                 T.gemm(S_shared, KV_shared, acc_o, policy=T.GemmWarpPolicy.FullCol)
             for i, j in T.Parallel(block_H, dim):
                 acc_o[i, j] /= logsum[i]
-            T.copy(acc_o, O_shared)
-            T.copy(O_shared, Output[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, :])
+            T.copy(acc_o, Output[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, :])
 
     if num_split > 1:
         return main_split

--- a/examples/deepseek_mla/example_mla_decode.py
+++ b/examples/deepseek_mla/example_mla_decode.py
@@ -233,7 +233,7 @@ def main(
 
     kernel = flashattn(batch, heads, kv_heads, kv_ctx, dim, pe_dim, BLOCK_N, BLOCK_H, num_split, softmax_scale)
     profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Randn)
-    profiler.assert_allclose(ref_program, rtol=1e-4, atol=1e-4)
+    profiler.assert_allclose(ref_program, rtol=2e-4, atol=1e-4)
     latency = profiler.do_bench(warmup=500)
     print(f"Latency: {latency} ms")
     print(f"TFlops: {total_flops / latency * 1e-9} TFlops")

--- a/examples/deepseek_mla/example_mla_decode.py
+++ b/examples/deepseek_mla/example_mla_decode.py
@@ -247,8 +247,8 @@ def run_regression_perf(
     dim=512,
     pe_dim=64,
 ):
-    BLOCK_N = 64
-    BLOCK_H = min(64, heads // kv_heads)
+    BLOCK_N = 32
+    BLOCK_H = min(16, heads // kv_heads)
     num_split = 1
     softmax_scale = (dim + pe_dim) ** -0.5
 

--- a/examples/deepseek_mla/test_example_mla_decode.py
+++ b/examples/deepseek_mla/test_example_mla_decode.py
@@ -7,7 +7,6 @@ _is_cutedsl = os.environ.get("TILELANG_TARGET", "").lower() == "cutedsl"
 
 
 @tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 @pytest.mark.skipif(_is_cutedsl, reason="CuTeDSL backend does not support alloc_global yet")
 def test_example_mla_decode():
     example_mla_decode.main()

--- a/examples/deepseek_v32/sparse_mla_bwd.py
+++ b/examples/deepseek_v32/sparse_mla_bwd.py
@@ -91,7 +91,7 @@ def bwd(
     is_causal=True,
     block_size=32,
     num_stages=0,
-    threads=256,
+    threads=128,
     indices_dtype=T.int32,
     dtype=T.bfloat16,
     accum_dtype=T.float32,
@@ -121,7 +121,7 @@ def bwd(
 
     H = H_kv
     padded_H = max(tilelang.math.next_power_of_2(H_kv), 16)
-    block_H = min(64, padded_H)
+    block_H = min(16, padded_H)
     assert padded_H % block_H == 0
     NH = padded_H // block_H
     BS = block_size
@@ -143,7 +143,7 @@ def bwd(
         Q_tail_shared = T.alloc_shared([block_H, D_tail], dtype)
         KV_shared = T.alloc_shared([BS, D], dtype)
         KV_tail_shared = T.alloc_shared([BS, D_tail], dtype)
-        dO_shared = T.alloc_shared([block_H, D], dtype)
+        dO_shared = Q_shared
         mask = T.alloc_fragment([BS], "bool")
 
         P_shared_cast = T.alloc_shared([block_H, BS], dtype)
@@ -162,9 +162,7 @@ def bwd(
 
         max_kv_i = s_i
 
-        T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, :D], Q_shared)
         T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, D:], Q_tail_shared)
-        T.copy(dO[by, s_i, bz * block_H : (bz + 1) * block_H, :D], dO_shared)
 
         T.clear(acc_dq)
         T.clear(acc_dq_tail)
@@ -183,6 +181,7 @@ def bwd(
             for bi_i, d_i in T.Parallel(BS, D):
                 KV_shared[bi_i, d_i] = KV[by, Indices[by, s_i, bz // NH, i_i * BS + bi_i], bz // NH, d_i]
 
+            T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, :D], Q_shared)
             T.gemm(Q_shared, KV_shared, acc_p, transpose_B=True, policy=T.GemmWarpPolicy.FullCol)
 
             for bi_i, d_i in T.Parallel(BS, D_tail):
@@ -194,6 +193,7 @@ def bwd(
 
             T.copy(acc_p, P_shared_cast)
 
+            T.copy(dO[by, s_i, bz * block_H : (bz + 1) * block_H, :D], dO_shared)
             T.gemm(dO_shared, KV_shared, acc_dp, transpose_B=True, policy=T.GemmWarpPolicy.FullCol, clear_accum=True)
 
             for h_i, bi_i in T.Parallel(block_H, BS):
@@ -203,7 +203,9 @@ def bwd(
             T.gemm(dP_shared_cast, KV_shared, acc_dq, policy=T.GemmWarpPolicy.FullCol)
             T.gemm(dP_shared_cast, KV_tail_shared, acc_dq_tail, policy=T.GemmWarpPolicy.FullCol)
 
+            T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, :D], Q_shared)
             T.gemm(dP_shared_cast, Q_shared, acc_dkv, transpose_A=True, policy=T.GemmWarpPolicy.FullCol, clear_accum=True)
+            T.copy(dO[by, s_i, bz * block_H : (bz + 1) * block_H, :D], dO_shared)
             T.gemm(P_shared_cast, dO_shared, acc_dkv, transpose_A=True, policy=T.GemmWarpPolicy.FullCol)
 
             T.clear(acc_dkv_tail)

--- a/examples/deepseek_v32/sparse_mla_fwd.py
+++ b/examples/deepseek_v32/sparse_mla_fwd.py
@@ -62,14 +62,15 @@ def sparse_mla_fwd(
     NI = tilelang.cdiv(topk, block_I)
     D = dim
     D_tail = tail_dim
+    HEAD_TILE = 32
 
-    if head_kv > 64:
-        assert head_kv % 64 == 0, "head_kv should be a multiple of 64"
-        REPLICATE_H = head_kv // 64
+    if head_kv > HEAD_TILE:
+        assert head_kv % HEAD_TILE == 0, "head_kv should be a multiple of 32"
+        REPLICATE_H = head_kv // HEAD_TILE
     else:
         REPLICATE_H = 1
 
-    H_per_block = padded_H if REPLICATE_H == 1 else 64
+    H_per_block = padded_H if REPLICATE_H == 1 else HEAD_TILE
 
     Q: T.Tensor(q_shape, dtype)  # type: ignore
     KV: T.Tensor(kv_shape, dtype)  # type: ignore
@@ -108,7 +109,7 @@ def sparse_mla_fwd(
         q_i = s_i
         max_kv_i = q_i
 
-        H0 = g_i * padded_H + (0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * 64)
+        H0 = g_i * padded_H + (0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * HEAD_TILE)
         H1 = H0 + H_per_block
 
         T.copy(Q[b_i, s_i, H0:H1, :D], Q_shared)
@@ -168,7 +169,7 @@ def sparse_mla_fwd(
     return Output, Lse
 
 
-def sparse_mla_fwd_interface(q, kv, indices, sm_scale=None, return_p_sum: bool = False, d_v=512, block_I=64, num_stages=2, threads=256):
+def sparse_mla_fwd_interface(q, kv, indices, sm_scale=None, return_p_sum: bool = False, d_v=512, block_I=16, num_stages=1, threads=128):
     is_casual = True
     assert return_p_sum == False, "This kernel file is for fwd only"
     assert q.is_contiguous() and kv.is_contiguous() and indices.is_contiguous()
@@ -238,9 +239,9 @@ def test_sparse_mla_fwd(
     topk=2048,
     dtype=torch.bfloat16,
     check_correctness=True,
-    block_I=64,
-    num_stages=2,
-    threads=256,
+    block_I=16,
+    num_stages=1,
+    threads=128,
 ):
     torch.random.manual_seed(0)
     q = torch.randn((B, S, H, DQK), dtype=dtype, device="cuda").requires_grad_(True)

--- a/examples/deepseek_v32/test_tilelang_example_deepseek_v32.py
+++ b/examples/deepseek_v32/test_tilelang_example_deepseek_v32.py
@@ -10,19 +10,16 @@ import sparse_mla_bwd
 
 
 @tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
 def test_example_topk_selector():
     topk_selector.test_topk_selector()
 
 
 @tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
 def test_example_fp8_lighting_indexer():
     fp8_lighting_indexer.test_fp8_lighting_indexer(S=512, SKV=1024, H=32, HKV=1, D=64, kv_stride=1)
 
 
 @tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
 def test_example_sparse_mla_fwd():
     # small shapes for testing
     sparse_mla_fwd.test_sparse_mla_fwd(S=256, SKV=1024, H=64, HKV=1, DQK=576, DV=512, topk=256, check_correctness=False)
@@ -36,7 +33,6 @@ def test_example_sparse_mla_fwd_pipelined():
 
 
 @tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
 def test_example_sparse_mla_bwd():
     sparse_mla_bwd.test_sparse_mla_bwd(S=256, SKV=512, H=64, HKV=1, DQKV=576, DV=512, topk=256, check_correctness=True)
     sparse_mla_bwd.test_sparse_mla_bwd(S=256, SKV=512, H=128, HKV=1, DQKV=576, DV=512, topk=256, check_correctness=True)  # test for large H

--- a/examples/deepseek_v4/test_tilelang_example_deepseek_v4.py
+++ b/examples/deepseek_v4/test_tilelang_example_deepseek_v4.py
@@ -19,7 +19,6 @@ def test_example_fp8_fp4_gemm_1d1d():
 
 
 @tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
 def test_example_sparse_attn_fwd_sm90():
     sparse_attn_fwd_sm90.test_correctness()
 

--- a/examples/dequantize_gemm/example_dequant_gemm_fp4_hopper.py
+++ b/examples/dequantize_gemm/example_dequant_gemm_fp4_hopper.py
@@ -242,8 +242,8 @@ def main(m=256, n=256, k=256, tune=False):
             num_bits=4,
             block_M=128,
             block_N=128,
-            block_K=128,
-            num_stages=2,
+            block_K=64,
+            num_stages=1,
             threads=256,
             split=1,
         )

--- a/examples/dequantize_gemm/test_example_dequantize_gemm.py
+++ b/examples/dequantize_gemm/test_example_dequantize_gemm.py
@@ -6,14 +6,12 @@ import example_dequant_gemm_bf16_mxfp4_hopper
 import example_dequant_gemm_w4a8
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_example_dequant_gemv_fp16xint4():
     example_dequant_gemv_fp16xint4.main()
 
 
 @tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
 def test_example_dequant_gemm_fp4_hopper():
     example_dequant_gemm_fp4_hopper.main()
 

--- a/examples/grouped_gemm/example_grouped_gemm_fwd_ptr.py
+++ b/examples/grouped_gemm/example_grouped_gemm_fwd_ptr.py
@@ -134,7 +134,7 @@ def run_tilelang_grouped_gemm_ptr(
     # execution path; CuTeDSL does not support these handle tensors.
     kernel = tl.compile(
         program,
-        target="cuda",
+        target="maca",
         execution_backend="auto",
         pass_configs={"tl.disable_warp_specialized": True},
     )

--- a/examples/grouped_gemm/test_example_grouped_gemm.py
+++ b/examples/grouped_gemm/test_example_grouped_gemm.py
@@ -6,7 +6,6 @@ import example_grouped_gemm_fwd_ptr
 
 
 @tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version(9, 0)
 def test_example_grouped_gemm_fwd_small():
     example_grouped_gemm_fwd.run_tilelang_grouped_gemm(
         [5, 9, 13],
@@ -23,7 +22,6 @@ def test_example_grouped_gemm_fwd_small():
 
 
 @tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version(9, 0)
 def test_example_grouped_gemm_fwd_ptr_small():
     example_grouped_gemm_fwd_ptr.run_tilelang_grouped_gemm_ptr(
         [5, 9, 13],
@@ -39,7 +37,6 @@ def test_example_grouped_gemm_fwd_ptr_small():
 
 
 @tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version(9, 0)
 def test_example_grouped_gemm_bwd_small():
     example_grouped_gemm_bwd.run_tilelang_grouped_gemm(
         [5, 9, 13],

--- a/src/transform/lower_thread_allreduce.cc
+++ b/src/transform/lower_thread_allreduce.cc
@@ -35,6 +35,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "../target_utils.h"
 #include "runtime/thread_storage_scope.h"
 #include "tir/transforms/ir_utils.h"
 #include "tir/transforms/update_pointer_storage_scope.h"
@@ -392,6 +393,9 @@ private:
                         contiguous_reduce_extent)) {
       std::vector<PrimExpr> reduce_results;
       DataType mask_dtype = DataType::UInt(32);
+      if (target_ != nullptr && TargetIsMaca(GetRef<Target>(target_))) {
+        mask_dtype = DataType::UInt(64);
+      }
       PrimExpr mask = Call(mask_dtype, builtin::tvm_warp_activemask(), {});
 
       if (reduce_extent <= warp_size_) {

--- a/src/transform/lower_thread_allreduce.cc
+++ b/src/transform/lower_thread_allreduce.cc
@@ -35,7 +35,7 @@
 #include <unordered_set>
 #include <utility>
 
-#include "../target/utils.h"
+#include "../maca/target_utils.h"
 #include "runtime/thread_storage_scope.h"
 #include "tir/transforms/ir_utils.h"
 #include "tir/transforms/update_pointer_storage_scope.h"

--- a/src/transform/lower_thread_allreduce.cc
+++ b/src/transform/lower_thread_allreduce.cc
@@ -35,7 +35,7 @@
 #include <unordered_set>
 #include <utility>
 
-#include "../maca/target_utils.h"
+#include "backend/common/target_utils.h"
 #include "runtime/thread_storage_scope.h"
 #include "tir/transforms/ir_utils.h"
 #include "tir/transforms/update_pointer_storage_scope.h"

--- a/src/transform/lower_thread_allreduce.cc
+++ b/src/transform/lower_thread_allreduce.cc
@@ -35,7 +35,7 @@
 #include <unordered_set>
 #include <utility>
 
-#include "../target_utils.h"
+#include "../target/utils.h"
 #include "runtime/thread_storage_scope.h"
 #include "tir/transforms/ir_utils.h"
 #include "tir/transforms/update_pointer_storage_scope.h"

--- a/src/transform/lower_thread_allreduce.cc
+++ b/src/transform/lower_thread_allreduce.cc
@@ -854,7 +854,7 @@ private:
   bool IsWarpReduction(const std::vector<DataType> &types, int group_extent,
                        int reduce_extent, int contiguous_reduce_extent) {
     if ((target_->kind->name != "cuda") && (target_->kind->name != "rocm") &&
-        (target_->kind->name != "metal")) {
+        (target_->kind->name != "metal") && (target_->kind->name != "maca")) {
       return false;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Updated the DeepSeek V3.2 sparse MLA backward kernel scheduling (`examples/deepseek_v32/sparse_mla_bwd.py`): reduced `bwd` default `threads` (256→128), tightened `block_H` tiling (`min(64, padded_H)`→`min(16, padded_H)`), and revised shared-memory/data-loading order by aliasing `dO_shared` to `Q_shared` and reordering/reloading `Q_shared`/`dO_shared` around the GEMM/probability stages.
- Updated the DeepSeek V3.2 sparse MLA forward interface and head tiling (`examples/deepseek_v32/sparse_mla_fwd.py`): introduced a 32-wide head-tile (`HEAD_TILE = 32`) approach and changed interface defaults (`block_I` 64→16, `num_stages` 2→1, `threads` 256→128), with corresponding test default alignment.
- Relaxed CUDA compute-version gating for multiple DeepSeek examples/tests: switched several decorators to `@tilelang.testing.requires_cuda`, added a backend-specific skip for `cutedsl` in `test_example_mla_decode`, and adjusted the DeepSeek V3.2 example test module gating accordingly.
- Updated dequantize GEMM/GEVM example/test expectations:
  - FP4 Hopper path defaults changed (`block_K` 128→64, `num_stages` 2→1) and compute-version gating removed for the Hopper test.
  - FP16xint4 GEMV test un-xfailed.
- Updated C++ lowering (`src/transform/lower_thread_allreduce.cc`): treat `maca` as a supported target for warp reduction and use `tvm_warp_activemask` datatype `UInt(64)` for `maca` (otherwise `UInt(32)`).
- Updated grouped GEMM pointer example/tests to use `maca`/broaden gating:
  - Grouped GEMM pointer kernel compilation target changed from `cuda`→`maca` (`examples/grouped_gemm/example_grouped_gemm_fwd_ptr.py`).
  - Grouped GEMM tests dropped compute-version gating and now use only `@tilelang.testing.requires_cuda` (`examples/grouped_gemm/test_example_grouped_gemm.py`).

## C++ style / lint notes
- The PR does not modify `docs/developer_guide/cpp_style.md`, but it touches C++ implementation code under `src/` (`src/transform/lower_thread_allreduce.cc`).
- It adds/updates C++ code paths (target gating + datatype selection) and includes `backend/common/target_utils.h`; this is correctness-related, not a style-only churn.
- The doc notes the C++ API style audit via `maint/scripts/audit_cpp_api_style.py`, which CI runs in **warning-only** mode so new findings are visible without blocking. This PR makes no API/FFI naming changes (only internal lowering behavior), so it should not introduce TLCPP003/TLCPP004-style public interface/compatibility risks; any audit findings would be advisory and should be addressed only if they relate to this touched implementation area.
- Correctness/build/test vs warnings:
  - Correctness: functional change to warp reduction handling for `maca`.
  - Build/test: no test/CI gating changes from the C++ edit itself.
  - Warning-only: any style/audit suggestions from the advisory audit should be reviewed and handled case-by-case (fix/suppress for this file if relevant), without treating TLCPP003/TLCPP004 as blocking unless a new API/FFI/maintainability risk is introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->