### PR TITLE
[CI] Update MACA version from 3.7 into 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,6 @@ jobs:
             uv pip install -v -r requirements-test-rocm.txt
           elif [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
             uv pip install -r requirements-test-maca.txt
-            uv pip install flash_linear_attention==0.5.0 -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
           elif [[ "${{ matrix.runner.toolkit }}" == *"Metal"* ]]; then
             uv pip install -v -r requirements-test-metal.txt
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,6 @@ jobs:
     strategy:
       matrix:
         runner:
-          # - tags: [self-hosted, nvidia]
-          #   name: self-hosted-nvidia
-          #   # Format: [Nightly-]CUDA-<major>.<minor>[.<patch>]. E.g., "CUDA-12.8" or "Nightly-CUDA-13.0".
-          #   # Use "Nightly-" prefix to use torch nightly builds.
-          #   toolkit: CUDA-12.8
           # ROCm CI is temporarily disabled.
           # - tags: [self-hosted, amd, gpu]
           #   name: self-hosted-amd
@@ -98,7 +93,7 @@ jobs:
           - tags: tilelang-metax-runner
             name: self-hosted-metax
             # Format: MACA-<major>.<minor>[.<patch>]. E.g., "MACA-3.0".
-            toolkit: MACA-3.7
+            toolkit: MACA-3.8
           - tags: [macos-latest]
             name: macos-latest
             toolkit: Metal # or Nightly-Metal
@@ -108,13 +103,6 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - name: Install dependencies for runner (MetaX)
-        if: contains(matrix.runner.toolkit, 'MACA')
-        run: |
-          sudo apt-get update && sudo apt-get install -y git ccache
-          export PATH="/opt/conda/bin:${PATH}"
-          echo "PATH=${PATH}" | tee -a "${GITHUB_ENV}"
-
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
@@ -252,7 +240,6 @@ jobs:
           export UV_INDEX="http://mirrors.aliyun.com/pypi/simple"
           export CLANG_TIDY_CMAKE_OPTIONS="${CLANG_TIDY_CMAKE_OPTIONS} -DUSE_MACA=ON"
 
-          echo "USE_MACA=ON" | tee -a "${GITHUB_ENV}"
           echo "UV_INDEX=${UV_INDEX}" | tee -a "${GITHUB_ENV}"
           echo "CLANG_TIDY_CMAKE_OPTIONS=${CLANG_TIDY_CMAKE_OPTIONS}" | tee -a "${GITHUB_ENV}"
 
@@ -315,7 +302,6 @@ jobs:
             uv pip install -v -r requirements-test-rocm.txt
           elif [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
             uv pip install -r requirements-test-maca.txt
-            uv pip install --no-deps --python-version 3.10.0 flash_linear_attention==0.4.0 -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
           elif [[ "${{ matrix.runner.toolkit }}" == *"Metal"* ]]; then
             uv pip install -v -r requirements-test-metal.txt
           else
@@ -391,7 +377,7 @@ jobs:
             uv run --no-project -m --
             pytest --verbose --color=yes --durations=0 --showlocals --cache-clear
           )
-          "${PYTEST[@]}" --maxfail=3 \
+          "${PYTEST[@]}" --maxfail=3 --numprocesses=4 \
             ../examples
 
       # NVIDIA CUDA tests
@@ -432,7 +418,7 @@ jobs:
             uv run --no-project -m --
             pytest --verbose --color=yes --durations=0 --showlocals --cache-clear
           )
-          "${PYTEST[@]}" --maxfail=3 --numprocesses=2 \
+          "${PYTEST[@]}" --maxfail=3 --numprocesses=4 \
             --ignore=./python/metal \
             --ignore=./python/issue/test_tilelang_issue_sm120_tma_smem_alignment.py \
             --ignore=./python/jit/test_tilelang_jit_cutedsl_host_codegen.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,7 @@ jobs:
             uv pip install -v -r requirements-test-rocm.txt
           elif [[ "${{ matrix.runner.toolkit }}" == *"MACA"* ]]; then
             uv pip install -r requirements-test-maca.txt
+            uv pip install flash_linear_attention==0.5.0 -i https://repos.metax-tech.com/r/maca-pypi/simple --trusted-host repos.metax-tech.com
           elif [[ "${{ matrix.runner.toolkit }}" == *"Metal"* ]]; then
             uv pip install -v -r requirements-test-metal.txt
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,7 +418,7 @@ jobs:
             uv run --no-project -m --
             pytest --verbose --color=yes --durations=0 --showlocals --cache-clear
           )
-          "${PYTEST[@]}" --maxfail=3 --numprocesses=4 \
+          "${PYTEST[@]}" --maxfail=3 --numprocesses=2 \
             --ignore=./python/metal \
             --ignore=./python/issue/test_tilelang_issue_sm120_tma_smem_alignment.py \
             --ignore=./python/jit/test_tilelang_jit_cutedsl_host_codegen.py \

--- a/docker/Dockerfile.metax
+++ b/docker/Dockerfile.metax
@@ -1,14 +1,11 @@
-FROM sw-harbor-lt.mxcr.io/cimaster/maca-pytorch:20260227-616-torch2.6-py310-ubuntu24.04-amd64
+FROM cr.metax-tech.com/public-library/maca-pytorch:3.8.0.11-torch2.10-py312-ubuntu24.04-amd64
 
 WORKDIR /root
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    git \
-    cmake
+RUN apt-get update && apt-get install -y git cmake ccache
 
-ENV USE_MACA=ON
+ENV USE_MACA=ON PATH="/opt/conda/bin:${PATH}"
 
 CMD bash

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -18,7 +18,7 @@ cython
 docutils
 dtlib
 einops
-flash-linear-attention==0.5.0
+flash-linear-attention==0.3.2
 matplotlib
 packaging>=21.0
 pandas

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -18,7 +18,7 @@ cython
 docutils
 dtlib
 einops
-flash-linear-attention==0.3.2
+flash-linear-attention==0.5.0
 matplotlib
 packaging>=21.0
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ ml-dtypes
 numpy>=1.23.5
 psutil
 torch
-torch>=2.7; platform_system == 'Darwin'
+torch>=2.7,<=2.10; platform_system == 'Darwin'
 tqdm>=4.62.3
 typing-extensions>=4.10.0
 z3-solver>=4.13.0,<4.15.5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### CI
- Updated the CI runner matrix to use `MACA-3.8` instead of `MACA-3.7`.
- Simplified the MACA setup to rely on the existing MACA requirements install path (`requirements-test-maca.txt`) and kept the MACA-specific configuration confined to the environment step (via `CLANG_TIDY_CMAKE_OPTIONS` adding `-DUSE_MACA=ON`).
- Reduced MACA example parallelism: `Run MACA examples` uses `--numprocesses=4`.
- Set MetaXGPU/MACA test parallelism to `--numprocesses=2` for the `Run MACA tests` step.
- Removed/disabled previously commented-out self-hosted GPU runner entries.

### Docker
- Updated `docker/Dockerfile.metax` to use the MACA 3.8 / torch2.10 / py312 Ubuntu 24.04 base image.
- Adjusted container setup: set `WORKDIR /root`, use `DEBIAN_FRONTEND=noninteractive`, install `git`/`cmake`/`ccache` (dropping prior `build-essential` pattern), set `USE_MACA=ON`, and prepend `/opt/conda/bin` to `PATH`.
- Left the container entrypoint behavior unchanged.

### Dependencies
- Updated `flash-linear-attention` pin in `requirements-test.txt` from `0.3.2` to `0.5.0`.
- Tightened macOS/Darwin `torch` constraint in `requirements.txt` to `>=2.7` and `<=2.10`.

### C++ style / lint notes
- Does not touch C++ sources or `docs/developer_guide/cpp_style.md`.
- The CI “C++ API Style Audit (warning only)” step remains present and warning-only; this PR is limited to CI/Docker/requirements changes and does not introduce new C++ API/FFI/maintainability risk, so any TLCPP003/TLCPP004-style findings (if they appear) should be treated as advisory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->