### PR TITLE
[BugFix][MetaxGPU] Reject float accumulators the MACA matrix core cannot hold

### DIFF
--- a/testing/python/maca/test_maca_mma_accum_dtype.py
+++ b/testing/python/maca/test_maca_mma_accum_dtype.py
@@ -1,0 +1,69 @@
+import pytest
+
+import tilelang.language as T
+import tilelang.testing
+from tilelang.maca.intrinsics.macro.mma_macro_generator import (
+    TensorCoreIntrinEmitter,
+    TensorCorePreshuffleIntrinEmitter,
+)
+from tilelang.maca.intrinsics.macro.mma_sp_macro_generator import SparseTensorCoreIntrinEmitter
+
+DENSE_EMITTERS = [TensorCoreIntrinEmitter, TensorCorePreshuffleIntrinEmitter]
+ALL_EMITTERS = [*DENSE_EMITTERS, SparseTensorCoreIntrinEmitter]
+
+
+_UNSET = object()
+
+
+def _emitter(emitter_cls, a_dtype=T.float16, b_dtype=T.float16, accum_dtype=_UNSET):
+    common = {
+        "a_dtype": a_dtype,
+        "b_dtype": b_dtype,
+        "a_transposed": False,
+        "b_transposed": True,
+        "block_row_warps": 2,
+        "block_col_warps": 2,
+        "warp_row_tiles": 32,
+        "warp_col_tiles": 32,
+    }
+    # Left out of the kwargs when unset, so the emitter's own default is what gets exercised.
+    if accum_dtype is not _UNSET:
+        common["accum_dtype"] = accum_dtype
+    if emitter_cls is SparseTensorCoreIntrinEmitter:
+        return emitter_cls(e_dtype=T.uint8, warp_k=16, **common)
+    return emitter_cls(chunk=32, **common)
+
+
+@pytest.mark.parametrize("emitter_cls", ALL_EMITTERS)
+@pytest.mark.parametrize("accum_dtype", [T.float16, T.bfloat16, T.float8_e4m3, T.float8_e5m2])
+def test_narrow_float_accumulation_is_rejected(emitter_cls, accum_dtype):
+    # codegen builds the builtin name as `"__builtin_mxc_mma_" + prefix` and casts C to
+    # `dtype_map[accum_dtype + "x4"]` (src/maca/codegen/codegen_maca.cc). The float
+    # matrix-core builtins take and return a float32x4, so any float accumulator narrower
+    # than 32 bits hands them the wrong vector type and mxcc rejects the call — an opaque
+    # error several stages downstream. On upstream, each of these fails to compile.
+    with pytest.raises(ValueError, match="does not support .* accumulation"):
+        _emitter(emitter_cls, accum_dtype=accum_dtype)
+
+
+@pytest.mark.parametrize("emitter_cls", ALL_EMITTERS)
+def test_fp32_accumulation_is_the_default(emitter_cls):
+    emitter = _emitter(emitter_cls)
+
+    assert emitter.accum_dtype == T.float32
+    assert emitter.accum_dtype_abbrv == "fp32"
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("emitter_cls", DENSE_EMITTERS)
+def test_int32_accumulation_is_still_accepted(emitter_cls):
+    # The int8 shapes accumulate in int32, so rejecting fp16 must not spill over onto them.
+    # This is the only case that needs a live target: `_initialize_k_dim` calls
+    # `determine_target()` on the 8-bit branch alone, to read `mcpu`.
+    emitter = _emitter(emitter_cls, a_dtype=T.int8, b_dtype=T.int8, accum_dtype=T.int32)
+
+    assert emitter.accum_dtype_abbrv == "int32"
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/maca/intrinsics/macro/mma_macro_generator.py
+++ b/tilelang/maca/intrinsics/macro/mma_macro_generator.py
@@ -35,6 +35,26 @@ from tilelang.maca.intrinsics.layout.mma_layout import (
 lift = convert
 
 
+def _reject_narrow_float_accum(normalized: str) -> None:
+    """Reject an accumulator the MACA matrix core cannot hold.
+
+    codegen synthesises the builtin as ``"__builtin_mxc_mma_" + prefix`` and casts the C
+    operand to ``dtype_map[accum_dtype + "x4"]`` (src/maca/codegen/codegen_maca.cc, the
+    tl::mma lowering). The float matrix-core builtins take and return a float32x4, so any
+    float accumulator narrower than 32 bits hands them the wrong vector type and mxcc
+    rejects the call. Integer shapes accumulate in int32 and stay valid. Left unchecked
+    the mismatch only surfaces as an opaque compiler error several stages later.
+    """
+    if not normalized.startswith(("float", "bfloat")):
+        return
+    if DataType(normalized).bits >= 32:
+        return
+    raise ValueError(
+        f"MACA MMA does not support {normalized} accumulation; the float matrix-core "
+        f"builtins accumulate in float32. Use accum_dtype='float32'."
+    )
+
+
 class TensorCoreIntrinEmitter:
     """
     To eliminate Python syntax within TIR Macro.
@@ -70,7 +90,7 @@ class TensorCoreIntrinEmitter:
         self,
         a_dtype: str = "float16",
         b_dtype: str = "float16",
-        accum_dtype: str = "float16",
+        accum_dtype: str = "float32",
         a_transposed: bool = False,
         b_transposed: bool = False,
         block_row_warps: int = 2,
@@ -151,15 +171,21 @@ class TensorCoreIntrinEmitter:
         self.local_size_b = (n_dim * k_dim) // warp_size
         self.local_size_out = (m_dim * n_dim) // warp_size
 
-    def _dtype_abbrv_lookup(self, dtype):
+    @staticmethod
+    def _normalize_dtype(dtype) -> str:
         s = str(dtype)
         if s.startswith("dtype('") and s.endswith("')"):
             s = s[7:-2]
+        return s
+
+    def _dtype_abbrv_lookup(self, dtype):
+        s = self._normalize_dtype(dtype)
         if s not in self.dtype_abbrv:
             raise KeyError(f"Unsupported dtype for MACA MMA: {dtype!r}")
         return self.dtype_abbrv[s]
 
     def _initialize_abbrev(self, a_dtype, b_dtype, accum_dtype):
+        _reject_narrow_float_accum(self._normalize_dtype(accum_dtype))
         self.a_dtype_abbrv = self._dtype_abbrv_lookup(a_dtype)
         self.b_dtype_abbrv = self._dtype_abbrv_lookup(b_dtype)
         self.accum_dtype_abbrv = self._dtype_abbrv_lookup(accum_dtype)
@@ -168,9 +194,7 @@ class TensorCoreIntrinEmitter:
         in_dtype = self.a_dtype
         M_DIM, N_DIM = self.M_DIM, self.N_DIM
 
-        in_dtype_key = str(in_dtype)
-        if in_dtype_key.startswith("dtype('") and in_dtype_key.endswith("')"):
-            in_dtype_key = in_dtype_key[7:-2]
+        in_dtype_key = self._normalize_dtype(in_dtype)
         in_dtype_map = {
             "bfloat16": "bf16",
             "float16": "f16",
@@ -776,7 +800,7 @@ class TensorCorePreshuffleIntrinEmitter(TensorCoreIntrinEmitter):
         self,
         a_dtype: str = "float16",
         b_dtype: str = "float16",
-        accum_dtype: str = "float16",
+        accum_dtype: str = "float32",
         a_transposed: bool = False,
         b_transposed: bool = False,
         block_row_warps: int = 2,

--- a/tilelang/maca/intrinsics/macro/mma_sp_macro_generator.py
+++ b/tilelang/maca/intrinsics/macro/mma_sp_macro_generator.py
@@ -11,6 +11,7 @@ from tvm.runtime import convert
 from ..layout.utils import mma_store_index_map
 from tilelang.utils import is_fragment, get_buffer_region_from_load
 from tilelang.maca.intrinsics.layout.mma_layout import *
+from tilelang.maca.intrinsics.macro.mma_macro_generator import _reject_narrow_float_accum
 
 
 lift = convert
@@ -47,7 +48,7 @@ class SparseTensorCoreIntrinEmitter:
         a_dtype: str = "float16",
         e_dtype: str = "uint8",
         b_dtype: str = "float16",
-        accum_dtype: str = "float16",
+        accum_dtype: str = "float32",
         a_transposed: bool = False,
         b_transposed: bool = False,
         e_transposed: bool = False,
@@ -131,10 +132,18 @@ class SparseTensorCoreIntrinEmitter:
         self.local_size_b = (n_dim * k_dim) // warp_size
         self.local_size_out = (m_dim * n_dim) // warp_size
 
+    @staticmethod
+    def _normalize_dtype(dtype) -> str:
+        s = str(dtype)
+        if s.startswith("dtype('") and s.endswith("')"):
+            s = s[7:-2]
+        return s
+
     def _initialize_abbrev(self, a_dtype, b_dtype, accum_dtype):
-        self.a_dtype_abbrv = self.dtype_abbrv[a_dtype]
-        self.b_dtype_abbrv = self.dtype_abbrv[b_dtype]
-        self.accum_dtype_abbrv = self.dtype_abbrv[accum_dtype]
+        _reject_narrow_float_accum(self._normalize_dtype(accum_dtype))
+        self.a_dtype_abbrv = self.dtype_abbrv[self._normalize_dtype(a_dtype)]
+        self.b_dtype_abbrv = self.dtype_abbrv[self._normalize_dtype(b_dtype)]
+        self.accum_dtype_abbrv = self.dtype_abbrv[self._normalize_dtype(accum_dtype)]
 
     def _initialize_mma_prefix(self, k_dim=16):
         in_dtype = self.a_dtype


### PR DESCRIPTION
Closes #69.

## Problem

The MMA lowering in `src/maca/codegen/codegen_maca.cc` synthesises the builtin name as `"__builtin_mxc_mma_" + prefix` and casts the C operand to `dtype_map[C_dtype]`, where `dtype_map["float16x4"] == "float16x4"`. The MACA float matrix-core builtins take and return a `float32x4`, so a narrow float accumulator hands them the wrong vector type:

```
error: cannot initialize a parameter of type
'__attribute__((__vector_size__(4 * sizeof(float)))) float' (vector of 4 'float' values)
with an lvalue of type 'float16x4' (vector of 4 'float16_t' values)
```

The emitter accepted it, so this only surfaced several stages later, inside mxcc.

`accum_dtype` defaulted to `float16` in all three emitters, so the default configuration could never compile on a MACA target.

## Changes

The check is on the accumulator width rather than on one dtype. On upstream, with fp16 inputs, a C500 compiles `float32` and `int32` and rejects every float type narrower than 32 bits:

| `accum_dtype` | upstream, no guard |
|---|---|
| `float32` | compiles |
| `int32` | compiles |
| `float16` | `RuntimeError` from mxcc |
| `bfloat16` | `RuntimeError` from mxcc |
| `float8_e4m3` | `RuntimeError` from mxcc |
| `float8_e5m2` | `RuntimeError` from mxcc |

`_reject_narrow_float_accum` raises a `ValueError` naming the offending dtype at emitter construction. It sits in one place and both the dense and the sparse emitter call it, so the two cannot drift apart. Integer shapes accumulate in `int32` and are untouched.

The three `accum_dtype` defaults move from `float16` to `float32`.

## Test Plan

`testing/python/maca/test_maca_mma_accum_dtype.py`, on a MetaX C500 (MACA 3.5.3.20):

- every narrow float accumulator — `float16`, `bfloat16`, `float8_e4m3`, `float8_e5m2` — is rejected, on all three emitters
- the default accumulator is `float32`, on all three emitters. The helper omits `accum_dtype` entirely for this case, so it is the emitter's own default that is exercised
- `int32` accumulation with `int8` inputs still constructs, so the rejection does not spill over onto the integer shapes

## Test Result

```
17 passed in 5.65s
```

Only the `int8` case needs a live target: `_initialize_k_dim` calls `determine_target()` on the 8-bit branch alone, to read `mcpu`. It carries `@tilelang.testing.requires_cuda`, which in this fork resolves to `_check_is_maca()`. The others run everywhere.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Reject unsupported narrow floating-point accumulation dtypes for MACA MMA emitters with an actionable `ValueError`.
- Default dense, preshuffle, and sparse MACA emitters to `float32` accumulation.
- Centralize dtype normalization and apply it to dtype abbreviation lookups and MMA prefix generation.
- Preserve `int32` accumulation support for integer MMA.
- Add tests for narrow floating-point rejection, `float32` defaults, and dense `int32` accumulation support.

MACA tests passed for the added coverage: 8 tests passed. The test runner was later OOM-killed with exit code 137.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->