### PR TITLE
[MetaxGPU][BugFix] Filter unsupported NVCC flags for mxcc

### DIFF
--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -235,6 +235,17 @@ def tilelang_callback_maca_compile(code, target, pass_config=None):
     if "--use_fast_math" in options:
         options.remove("--use_fast_math")
 
+    # Filter out NVCC-specific flags that mxcc does not support
+    _CUDA_ONLY_FLAGS = {
+        "--expt-relaxed-constexpr",
+        "--expt-extended-lambda",
+        "-U__CUDA_NO_HALF_OPERATORS__",
+        "-U__CUDA_NO_HALF_CONVERSIONS__",
+        "-U__CUDA_NO_HALF2_OPERATORS__",
+        "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+    }
+    options = [o for o in options if o not in _CUDA_ONLY_FLAGS]
+
     fatbin = mxcc.compile_maca(
         code,
         compile_format,


### PR DESCRIPTION
Filter unsupported NVCC flags for mxcc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Filters unsupported NVCC/CUDA-specific flags from compiler options before invoking `mxcc.compile_maca` for MetaxGPU builds, replacing the previous single-flag removal of `--use_fast_math`.

## C++ style / lint notes

Not applicable: this change does not modify C++ code, C++ style rules, lint tooling, or CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->