### PR TITLE
[MetaxGPU][codegen] Support target-independent builtins in MACA codegen

### DIFF
--- a/src/maca/codegen/codegen_maca.cc
+++ b/src/maca/codegen/codegen_maca.cc
@@ -1960,6 +1960,9 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
     std::string func_name =
         is_inc ? "tl::warpgroup_reg_alloc" : "tl::warpgroup_reg_dealloc";
     this->stream << func_name << "<" << std::to_string(nreg) << ">();\n";
+  } else if (op->op.same_as(tl::annotate_producer_reg_dealloc()) ||
+             op->op.same_as(tl::annotate_consumer_reg_alloc())) {
+    return;
   } else if (op->op.same_as(tl::wait_wgmma())) {
     this->PrintIndent();
     int num_mma = Downcast<IntImm>(op->args[0])->value;
@@ -1967,6 +1970,14 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
   } else if (op->op.same_as(tl::pack_b16())) {
     os << "__pack_half2(" << this->PrintExpr(op->args[0]) << ", "
        << this->PrintExpr(op->args[1]) << ")";
+  } else if (op->op.same_as(tl::pack_b8x4())) {
+    os << "tl::pack_b8x4(";
+    for (size_t i = 0; i < op->args.size(); ++i) {
+      if (i != 0)
+        os << ", ";
+      this->PrintExpr(op->args[i], os);
+    }
+    os << ")";
   } else if (op->op.same_as(tl::sync_grid())) {
     this->need_cooperative_groups_ = true;
     this->PrintIndent();
@@ -2040,6 +2051,14 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
       this->PrintExpr(op->args[i * 2 + 1], os);
       os << "]" << ((i < 3) ? ", " : ")");
     }
+  } else if (op->op.same_as(builtin::mma_fill())) {
+    std::string num_elem = this->PrintExpr(op->args[0]);
+    std::string dst = this->PrintExpr(op->args[1]);
+    std::string dst_offset = this->PrintExpr(op->args[2]);
+
+    os << "for (int i = 0; i < " << num_elem << "; ++i) {\n";
+    os << dst << "[" << dst_offset << " + i] = 0.0;";
+    os << "}\n";
   } else if (op->op.same_as(tl::tvm_mfma())) {
     // arg 0: prefix: {otype}_{intrM}x{intrN}x{intrK}_{itype}
     // arg 1: A layout: row/col

--- a/src/tl_templates/maca/common.h
+++ b/src/tl_templates/maca/common.h
@@ -281,6 +281,13 @@ TL_DEVICE unsigned int make_uint(unsigned char x0, unsigned char x1,
   return (x3 << 24) | (x2 << 16) | (x1 << 8) | x0;
 }
 
+template <typename T> TL_DEVICE unsigned int pack_b8x4(T x0, T x1, T x2, T x3) {
+  return make_uint(*reinterpret_cast<unsigned char *>(&x0),
+                   *reinterpret_cast<unsigned char *>(&x1),
+                   *reinterpret_cast<unsigned char *>(&x2),
+                   *reinterpret_cast<unsigned char *>(&x3));
+}
+
 // Pack eight char values.
 TL_DEVICE uint2 make_uint2(unsigned char x0, unsigned char x1, unsigned char x2,
                            unsigned char x3, unsigned char y0, unsigned char y1,


### PR DESCRIPTION
Add MACA codegen support for target-independent builtins that were previously only handled by CUDA codegen.
- Consume producer/consumer register allocation annotations as no-ops, matching CUDA and ROCm behavior.
- Lower 'tirx.mma_fill' to a linear accumulator zero-fill loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added MACA codegen handling for producer/consumer register allocation annotations as no-ops.
- Added MACA lowering for `tirx.mma_fill` using a linear accumulator zero-fill loop.
- Added MACA codegen and template support for `tl::pack_b8x4`.

## C++ style / lint notes

- This PR changes C++ code but does not appear to touch rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) may report advisory findings; these should remain separate from correctness, build, and test validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->