### PR TITLE
[MetaxGPU][testing] skip unsupported feature tests on MACA

### DIFF
--- a/examples/minference/test_vs_sparse_attn.py
+++ b/examples/minference/test_vs_sparse_attn.py
@@ -3,7 +3,7 @@ import tilelang.testing
 import example_vertical_slash_sparse_attn
 
 
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
 def test_vs_sparse_attn():
     example_vertical_slash_sparse_attn.main()

--- a/testing/python/language/test_tilelang_language_atomic.py
+++ b/testing/python/language/test_tilelang_language_atomic.py
@@ -298,7 +298,7 @@ def tma_atomic_add_program(out, explicit_swizzle=False):
             T.atomic_add(out, out_shared, use_tma=True)
 
 
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
 def test_tma_atomic_add():
     out = torch.zeros((16, 16), dtype=torch.float32, device="cuda")

--- a/testing/python/language/test_tilelang_language_float4_e2m1_unpacked_dtype.py
+++ b/testing/python/language/test_tilelang_language_float4_e2m1_unpacked_dtype.py
@@ -75,7 +75,7 @@ def _decode_tcgen05_formats(desc: int) -> tuple[int, int]:
     return (desc >> 7) & 0x7, (desc >> 10) & 0x7
 
 
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 def test_tcgen05_instr_desc_fp4_unpacked_x_fp8():
     fp4 = DataType("custom[float4_e2m1_unpacked]8")
     fp8 = DataType("float8_e4m3fn")
@@ -86,7 +86,7 @@ def test_tcgen05_instr_desc_fp4_unpacked_x_fp8():
     assert b_format == 0
 
 
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 def test_tcgen05_blockscaled_instr_desc_mxfp4_unpacked_x_mxfp8():
     fp4 = DataType("custom[float4_e2m1_unpacked]8")
     fp8 = DataType("float8_e4m3fn")

--- a/testing/python/language/test_tilelang_language_let.py
+++ b/testing/python/language/test_tilelang_language_let.py
@@ -50,7 +50,7 @@ def producer_bind_kernel(A: T.Tensor((64,), T.float16), B: T.Tensor((64,), T.flo
                 B[k * 32 + i] = A_shared[i]
 
 
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
 def test_producer_bind_kernel():
     kernel_source = producer_bind_kernel.get_kernel_source()

--- a/testing/python/language/test_tilelang_language_tma_1d.py
+++ b/testing/python/language/test_tilelang_language_tma_1d.py
@@ -54,7 +54,7 @@ def run_elementwise_add(M, N):
         assert "tma_load" in code and "CUtensorMap" in code
 
 
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 def test_tilelang_language_tma_1d():
     run_elementwise_add(128, 128)
     run_elementwise_add(256, 128)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Skip unsupported MACA feature tests on macOS.
- Replace expected-failure markers with skip markers in:
  - Sparse attention comparison.
  - TMA atomic add.
  - TCGEN05 descriptor construction.
  - Producer-bind kernel.
  - 1D TMA.
- Preserve all test logic and assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->