### PR TITLE
[MetaxGPU][templates] Add make_uint4(uchar×16) to match CUDA uint8x16 broadcast lowering

### DIFF
--- a/src/tl_templates/maca/common.h
+++ b/src/tl_templates/maca/common.h
@@ -294,6 +294,21 @@ TL_DEVICE uint2 make_uint2(unsigned char x0, unsigned char x1, unsigned char x2,
   return result;
 }
 
+// Pack sixteen char values.
+TL_DEVICE uint4 make_uint4(unsigned char x0, unsigned char x1, unsigned char x2,
+                           unsigned char x3, unsigned char y0, unsigned char y1,
+                           unsigned char y2, unsigned char y3, unsigned char z0,
+                           unsigned char z1, unsigned char z2, unsigned char z3,
+                           unsigned char w0, unsigned char w1, unsigned char w2,
+                           unsigned char w3) {
+  uint4 result;
+  result.x = make_uint(x0, x1, x2, x3);
+  result.y = make_uint(y0, y1, y2, y3);
+  result.z = make_uint(z0, z1, z2, z3);
+  result.w = make_uint(w0, w1, w2, w3);
+  return result;
+}
+
 // Pack two half_t values.
 TL_DEVICE unsigned __pack_half2(const half_t x, const half_t y) {
   unsigned v0 = *((unsigned short *)&x);


### PR DESCRIPTION
## Summary
- MACA codegen lowers `Broadcast` of `uint8x16` to `make_uint4` with 16 `unsigned char` arguments (same pattern as CUDA).
- `tl_templates/maca/common.h` already provided `make_int4(signed char×16)` and `make_uint2(unsigned char×8)`, but was missing the matching `make_uint4(unsigned char×16)` overload.
- Without it, mxcc only sees the builtin `make_uint4(uint, uint, uint, uint)` and fails with "requires 4 arguments, but 16 were provided". Pytest then surfaces a misleading `RuntimeError` that starts with `#include <tl_templates/maca/gemm.h>` (the head of the generated source dump).

## Fix
- Add the CUDA-equivalent 16-byte pack overload in `src/tl_templates/maca/common.h`, packing four `make_uint(...)` words into `uint4`.
- No codegen / schedule changes; contiguous `*(uint4*)` paths and the 4-arg builtin `make_uint4` are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a MACA `make_uint4` overload that accepts 16 `unsigned char` arguments.
- Packs the arguments into four 32-bit words through `make_uint`.
- Supports CUDA-style `uint8x16` broadcast lowering without `mxcc` argument-count errors.
- Leaves codegen, schedules, contiguous `*(uint4*)` paths, and the existing four-argument builtin unchanged.

## C++ style / lint notes

- The PR changes a C++ header but does not modify the rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit remains warning-only. No correctness, build, or test issue is identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->