### PR TITLE
[MetaxGPU][Parallel] Guard projected fragment loop layouts with thread lower bound.

### DIFF
--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -556,6 +556,26 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &layout_args,
                     loop_thread_extent + layout_args.thread_bounds->min));
   }
 
+  // [MACA] Subregion Parallel writes into an MMA fragment keep absolute
+  // forward_thread. With warp=64 multi-warp Square (e.g. (2,1)), a lower-M
+  // tile can land on tid [64,128) while ThreadExtent==block_size, so the
+  // upper-bound predicate above does not fire. Without thread>=min, non-owner
+  // threads still enter PartitionLoop and corrupt the fragment. Emit the
+  // lower bound when const_int_bound(forward_thread).min > 0.
+  if (!loop_layout_->IsCompletedReplicated()) {
+    arith::Analyzer thr_a;
+    for (size_t i = 0; i < loop_layout_->InputDim(); ++i) {
+      thr_a.Bind(InputPlaceholder(i),
+                 Range::FromMinExtent(0, loop_layout_->InputShape()[i]));
+    }
+    thr_a.Bind(ReplicationPlaceholder(),
+               Range::FromMinExtent(0, loop_layout_->ReplicateExtent()));
+    auto b = thr_a.const_int_bound(loop_layout_->GetForwardThread());
+    if (b->min_value != arith::ConstIntBound::kNegInf && b->min_value > 0) {
+      AddPredicate(GE(InputPlaceholder(0), Integer(b->min_value)));
+    }
+  }
+
   // Step 2: Check that the loop's partition can correctly align with all source
   // fragment, and infer layout only when it's not yet layout-ed.
   ValidateCandidateAgainstFragments(

--- a/testing/python/layout/test_tilelang_layout_inference.py
+++ b/testing/python/layout/test_tilelang_layout_inference.py
@@ -133,5 +133,67 @@ def test_copy_readback_from_fully_replicated_fragment_uses_rep_guard():
     _assert_single_thread_replicated_readback(src)
 
 
+# [MACA] Regression for Parallel subregion stores into an MMA fragment under
+# multi-warp Square (warp=64, threads=128 → often (2,1)): projected
+# forward_thread for the lower-M half has min>0; without thread>=min guards in
+# ParallelOp, non-owner threads corrupt the fragment before gemm.
+@tilelang.jit(out_idx=[-1])
+def _quadrant_parallel_fragment_write_gemm():
+    """4x Parallel(32,32) writes into one 64x64 fragment then T.gemm.
+
+    Reproduces the SSD microtile failure mode: non-common-index Parallel
+    writes must project the full MMA fragment layout (thread + local index).
+    """
+    tile = 64
+    half = 32
+
+    @T.prim_func
+    def main(
+        A_in: T.Tensor((tile, tile), T.float16),
+        B_in: T.Tensor((tile, tile), T.float16),
+        C_out: T.Tensor((tile, tile), T.float32),
+    ):
+        with T.Kernel(1, threads=128):
+            A_frag = T.alloc_fragment((tile, tile), T.float16)
+            B_shared = T.alloc_shared((tile, tile), T.float16)
+            C_frag = T.alloc_fragment((tile, tile), T.float32)
+            T.annotate_layout({B_shared: tilelang.layout.make_swizzled_layout(B_shared)})
+            T.clear(C_frag)
+
+            for i, j in T.Parallel(tile, tile):
+                B_shared[i, j] = B_in[i, j]
+
+            # Four quadrant writes with non-common indices on A_frag.
+            for i, j in T.Parallel(half, half):
+                A_frag[i, j] = A_in[i, j]
+            for i, j in T.Parallel(half, half):
+                A_frag[i, half + j] = A_in[i, half + j]
+            for i, j in T.Parallel(half, half):
+                A_frag[half + i, j] = A_in[half + i, j]
+            for i, j in T.Parallel(half, half):
+                A_frag[half + i, half + j] = A_in[half + i, half + j]
+
+            T.gemm(A_frag, B_shared, C_frag)
+
+            for i, j in T.Parallel(tile, tile):
+                C_out[i, j] = C_frag[i, j]
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+def test_quadrant_parallel_fragment_write_gemm_numeric():
+    """[MACA] Numeric check for the Parallel fragment-owner lower-bound fix."""
+    import torch
+
+    kernel = _quadrant_parallel_fragment_write_gemm()
+    tile = 64
+    a = torch.randn(tile, tile, dtype=torch.float16, device="cuda")
+    b = torch.randn(tile, tile, dtype=torch.float16, device="cuda")
+    c = kernel(a, b)
+    ref = torch.matmul(a.float(), b.float())
+    torch.testing.assert_close(c, ref, atol=1e-2, rtol=1e-2)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Summary
- When a `T.Parallel` loop writes a **subregion** of an MMA fragment (non-common
  indices), layout inference projects the buffer’s absolute `forward_thread` into
  the loop layout. That projection can land on a **contiguous but non-zero-based**
  thread band (e.g. lower-M half → tid `[64, 128)` under a 2-warp Square
  `(m_warp, n_warp) = (2, 1)` partition on MACA).
- Existing predicates already cover `thread_range` and, when
  `ThreadExtent < block_size`, an upper bound `thread < ThreadExtent`. They do
  **not** emit a lower bound when `ThreadExtent == block_size` but
  `min(forward_thread) > 0`, so threads outside the owner band still enter
  `PartitionLoop`, invert the map incorrectly, and corrupt fragment state before
  `T.gemm`.
- Re-enable the `const_int_bound(forward_thread)` guard in `ParallelOp::InferLayout`
  so that when `min_value > 0` we add `thread >= min_value`, restricting execution
  to the owning threads.
- Add a layout regression that fills a fragment via four quadrant
  `Parallel` writes (non-common indices), runs `T.gemm`, and checks numeric
  agreement with a reference matmul.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Re-enable the `const_int_bound(forward_thread)` guard in `ParallelOp::InferLayout`.
- Add a `thread >= min_value` predicate for non-replicated layouts with a positive minimum thread ID.
- Prevent non-owner threads from executing partitioned fragment writes.
- Add a regression test for quadrant-based `T.Parallel` writes, `T.gemm`, and numeric comparison with PyTorch.

## C++ style / lint notes

- The change does not modify rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) CI step remains advisory.
- Any style warnings are separate from correctness, build, and test validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->