### PR TITLE
[refactor][test]remove redundant code and identify non-functional test cases

### DIFF
--- a/src/maca/codegen/codegen_maca.cc
+++ b/src/maca/codegen/codegen_maca.cc
@@ -575,6 +575,18 @@ void CodeGenTileLangMACA::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
       os << GetTileLangFP6Type(t);
     }
     return;
+  } else if (t.is_float4_e2m1_unpacked()) {
+    LOG(FATAL) << "float4_e2m1_unpacked is a SMEM/TMA storage tag and must be "
+                  "lowered through shared-memory allocation";
+    return;
+  } else if (t.is_float4_e2m1fn()) {
+    enable_fp4_ = true;
+    if (t.lanes() <= 64) {
+      os << GetTileLangFP4Type(t);
+    } else {
+      fail = true;
+    }
+    return;
   } else if (t.is_tfloat32()) {
     if (t.is_scalar()) {
       os << "float";
@@ -589,14 +601,14 @@ void CodeGenTileLangMACA::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
     }
     if (!fail)
       return;
-  } else if (t.is_float4()) {
-    enable_fp4_ = true;
-    if (t.lanes() <= 64) {
-      os << GetTileLangFP4Type(t);
-    } else {
-      fail = true;
-    }
-    return;
+    // } else if (t.is_float4()) {
+    //   enable_fp4_ = true;
+    //   if (t.lanes() <= 64) {
+    //     os << GetTileLangFP4Type(t);
+    //   } else {
+    //     fail = true;
+    //   }
+    //   return;
   } else if (t == DataType::Bool()) {
     os << "bool";
     return;
@@ -632,7 +644,12 @@ void CodeGenTileLangMACA::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
     }
     case 4: {
       if (t.is_scalar()) {
-        os << "int";
+        enable_int8_ = true;
+        if (!t.is_uint()) {
+          os << "signed char";
+        } else {
+          os << "char";
+        }
         return;
       } else if (t.lanes() == 4) {
         os << "int16_t";
@@ -1743,6 +1760,11 @@ std::string CodeGenTileLangMACA::GetBufferRef(DataType t,
   const VarNode *buffer_var = buffer->data.get();
   std::ostringstream os;
   std::string vid = GetVarID(buffer_var);
+  // For fp4 packed buffers, use the packed buffer name for vector accesses
+  auto it = fp4_packed_buffers_.find(buffer_var);
+  if (it != fp4_packed_buffers_.end() && !t.is_scalar()) {
+    vid = it->second;
+  }
   std::string scope;
   if (alloc_storage_scope_.count(buffer_var)) {
     scope = alloc_storage_scope_.at(buffer_var);
@@ -3076,8 +3098,22 @@ void CodeGenTileLangMACA::VisitStmt_(const AllocBufferNode *op) {
     ICHECK(op->annotations.count("barrier_type"));
     stream << Downcast<StringImm>(op->annotations.at("barrier_type"))->value;
   } else {
-    PrintStorageScope(scope, stream);
-    PrintType(alloc_dtype, stream);
+    bool is_float4_unpacked_shared =
+        alloc_dtype.is_float4_e2m1_unpacked() &&
+        (scope == "shared" || scope == "shared.dyn");
+    bool is_fp4_scalar_local = alloc_dtype.is_float4_e2m1fn() &&
+                               alloc_dtype.is_scalar() && scope == "local";
+    bool is_int4_scalar_local =
+        (alloc_dtype == DataType::Int(4) || alloc_dtype == DataType::UInt(4)) &&
+        alloc_dtype.is_scalar() && scope == "local";
+    if (!is_fp4_scalar_local && !is_int4_scalar_local) {
+      PrintStorageScope(scope, stream);
+      if (is_float4_unpacked_shared) {
+        stream << "uint8_t";
+      } else {
+        PrintType(alloc_dtype, stream);
+      }
+    }
   }
 
   if (scope == "shared.dyn") {
@@ -3092,10 +3128,13 @@ void CodeGenTileLangMACA::VisitStmt_(const AllocBufferNode *op) {
     if (scope.find("wmma.") == 0) {
       constant_size = GetWmmaFragmentSize(scope, buffer, constant_size);
     }
-    if ((alloc_dtype == DataType::Int(4) || alloc_dtype == DataType::UInt(4) ||
-         alloc_dtype == DataType::Int(1)) &&
-        scope == "shared") {
-      constant_size = constant_size / (32 / alloc_dtype.bits());
+    bool is_byte_packed_4bit =
+        alloc_dtype == DataType::Int(4) || alloc_dtype == DataType::UInt(4) ||
+        (alloc_dtype.is_float4_e2m1fn() && alloc_dtype.is_scalar());
+    if (is_byte_packed_4bit && scope == "shared") {
+      constant_size = (constant_size + 1) / 2;
+    } else if (alloc_dtype == DataType::Int(1) && scope == "shared") {
+      constant_size = constant_size / 32;
     }
     if (scope == "shared") {
       stream << ' ' << vid << '[' << constant_size << "];\n";
@@ -3106,7 +3145,20 @@ void CodeGenTileLangMACA::VisitStmt_(const AllocBufferNode *op) {
       stream << "auto " << vid << " = reinterpret_cast<" << mbarrier_dtype_
              << "*>(" << v_id_mem << ");\n";
     } else if (scope == "local") {
-      stream << ' ' << vid << '[' << constant_size << "];\n";
+      if (alloc_dtype == DataType::Int(4) || alloc_dtype == DataType::UInt(4)) {
+        stream << "alignas(16) ";
+        PrintType(alloc_dtype, stream);
+        stream << ' ' << vid << '[' << (constant_size + 1) / 2 << "];\n";
+      } else {
+        if (alloc_dtype.is_float4_e2m1fn() && alloc_dtype.is_scalar()) {
+          auto vid_packed = vid + "_packed";
+          stream << "fp4_e2_2_t " << vid_packed << '['
+                 << (constant_size + 1) / 2 << "];\n";
+          fp4_packed_buffers_[op->buffer->data.get()] = vid_packed;
+        } else {
+          stream << ' ' << vid << '[' << constant_size << "];\n";
+        }
+      }
     } else if (scope == "local.var") {
       PrimExpr init = tirx::make_const(alloc_dtype, 0);
       auto init_it = op->annotations.find(tl::attr::kLocalVarInit);

--- a/src/maca/codegen/codegen_maca.cc
+++ b/src/maca/codegen/codegen_maca.cc
@@ -601,14 +601,14 @@ void CodeGenTileLangMACA::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
     }
     if (!fail)
       return;
-    // } else if (t.is_float4()) {
-    //   enable_fp4_ = true;
-    //   if (t.lanes() <= 64) {
-    //     os << GetTileLangFP4Type(t);
-    //   } else {
-    //     fail = true;
-    //   }
-    //   return;
+  } else if (t.is_float4()) {
+    enable_fp4_ = true;
+    if (t.lanes() <= 64) {
+      os << GetTileLangFP4Type(t);
+    } else {
+      fail = true;
+    }
+    return;
   } else if (t == DataType::Bool()) {
     os << "bool";
     return;

--- a/src/maca/codegen/codegen_maca.h
+++ b/src/maca/codegen/codegen_maca.h
@@ -160,6 +160,7 @@ private:
   std::unordered_map<const VarNode *, std::string> fragment_layouts;
   std::unordered_map<const VarNode *, IntImm> unroll_factor;
   std::optional<std::tuple<int64_t, int64_t, int64_t>> cluster_dims;
+  std::unordered_map<const VarNode *, std::string> fp4_packed_buffers_;
   friend void PrintConst(const FloatImmNode *op, std::ostream &os,
                          CodeGenTileLangMACA *p);
   void PrintWmmaScope(const std::string &scope, DataType t,

--- a/src/tl_templates/maca/common.h
+++ b/src/tl_templates/maca/common.h
@@ -706,3 +706,18 @@ TL_DEVICE maca_bfloat162 abs2(maca_bfloat162 a) { return __habs2(a); }
 TL_DEVICE half2 abs2(half2 a) { return __habs2(a); }
 
 } // namespace tl
+
+// MACA vector types are aggregate structs, so they do not accept the
+// function-style construction emitted by the generic C code generator (for
+// example, `longlong4(a, b, c, d)`).  The MACA SDK already provides the
+// corresponding make_* helpers.  Function-like macros only rewrite calls;
+// uses such as `longlong4 value` remain type declarations.
+#ifndef TILELANG_MACA_VECTOR_CONSTRUCTOR_COMPAT
+#define TILELANG_MACA_VECTOR_CONSTRUCTOR_COMPAT
+#define longlong2(...) make_longlong2(__VA_ARGS__)
+#define longlong3(...) make_longlong3(__VA_ARGS__)
+#define longlong4(...) make_longlong4(__VA_ARGS__)
+#define ulonglong2(...) make_ulonglong2(__VA_ARGS__)
+#define ulonglong3(...) make_ulonglong3(__VA_ARGS__)
+#define ulonglong4(...) make_ulonglong4(__VA_ARGS__)
+#endif

--- a/src/tl_templates/maca/reduce.h
+++ b/src/tl_templates/maca/reduce.h
@@ -135,6 +135,24 @@ struct MinOpNan_fp16x2 {
   }
 };
 
+struct SumOp_f32x2 {
+  TL_DEVICE float2 operator()(float2 const &x, float2 const &y) {
+    return tl::add2(x, y);
+  }
+};
+
+struct MaxOp_f32x2 {
+  TL_DEVICE float2 operator()(float2 const &x, float2 const &y) {
+    return tl::max2(x, y);
+  }
+};
+
+struct MinOp_f32x2 {
+  TL_DEVICE float2 operator()(float2 const &x, float2 const &y) {
+    return tl::min2(x, y);
+  }
+};
+
 struct BitAndOp {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) const {
     return x & y;

--- a/testing/python/components/test_cuda_shared_memory_alias_codegen.py
+++ b/testing/python/components/test_cuda_shared_memory_alias_codegen.py
@@ -38,7 +38,6 @@ def test_dynamic_shared_memory_merge_emits_named_aliases():
     assert _get_dynamic_shared_memory_bytes(artifact) == 128
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_static_and_local_fp4_allocations_use_packed_extents():
     @T.prim_func
@@ -49,7 +48,7 @@ def test_static_and_local_fp4_allocations_use_packed_extents():
             A_shared[126] = T.cast(0.0, T.float4_e2m1fn)
             A_local[126] = A_shared[126]
 
-    source = tilelang.lower(kernel, target="cuda").kernel_source
+    source = tilelang.lower(kernel, target="auto").kernel_source
 
     assert "fp4_e2_t A_shared[64];" in source
     assert "fp4_e2_2_t A_local_packed[64];" in source
@@ -90,7 +89,6 @@ def test_merged_dynamic_fp4_allocations_use_packed_sizes_and_offsets():
     assert _get_dynamic_shared_memory_bytes(artifact) == 128
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
     "dtype,storage_type",

--- a/testing/python/cuda/test_cuda_f32x2_intrinsics.py
+++ b/testing/python/cuda/test_cuda_f32x2_intrinsics.py
@@ -327,7 +327,7 @@ def test_codegen_auto_vec_fma_f32():
     assert "tl::fma2" in src, "Expected tl::fma2 in SM100 auto-vectorised CUDA source for float32 mul+add"
 
 
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize("op_name,reduce_func,packed_ops", _REDUCE_OPS, ids=[op[0] for op in _REDUCE_OPS])
 def test_codegen_auto_vec_reduce_f32_sm100(op_name, reduce_func, packed_ops):
@@ -346,7 +346,7 @@ def test_codegen_auto_vec_reduce_f32_no_sm80(op_name, reduce_func, packed_ops):
         assert f"tl::{packed_op}" not in src, f"tl::{packed_op} should not appear in pre-SM100 float32 {op_name} reduction"
 
 
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
     "reduce_func,packed_op",

--- a/testing/python/debug/test_pass_timing.py
+++ b/testing/python/debug/test_pass_timing.py
@@ -18,8 +18,6 @@ from tilelang.utils.pass_timing import (
 )
 
 
-@tilelang.testing.pytest.mark.xfail
-@tilelang.testing.requires_cuda
 def _simple_module():
     @T.prim_func
     def program(A: T.Tensor((16,), "float32"), B: T.Tensor((16,), "float32")):
@@ -30,7 +28,6 @@ def _simple_module():
     return tvm.IRModule({"main": program})
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_pass_timing_records_simple_pass():
     timing = TileLangPassTimingInstrument()
@@ -44,7 +41,6 @@ def test_pass_timing_records_simple_pass():
     assert all(0 <= record.self_duration_s <= record.duration_s for record in timing.records)
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_pass_timing_wrapper_can_be_collected():
     timing = TileLangPassTimingInstrument()
@@ -58,7 +54,6 @@ def test_pass_timing_wrapper_can_be_collected():
     assert state_ref() is None
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_build_pass_instruments_prepends_timing():
     base_instrument = object()
@@ -70,7 +65,6 @@ def test_build_pass_instruments_prepends_timing():
     assert instruments[1] is base_instrument
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_build_pass_instruments_without_profile_preserves_base_instruments():
     base_instrument = object()
@@ -81,7 +75,6 @@ def test_build_pass_instruments_without_profile_preserves_base_instruments():
     assert instruments == [base_instrument]
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_pass_timing_excludes_later_after_pass_callbacks(monkeypatch):
     clock = [0.0]
@@ -102,7 +95,6 @@ def test_pass_timing_excludes_later_after_pass_callbacks(monkeypatch):
     assert clock[0] == 1.0
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_pass_timing_calculates_nested_self_time(monkeypatch):
     timing = TileLangPassTimingInstrument()
@@ -125,7 +117,6 @@ def test_pass_timing_calculates_nested_self_time(monkeypatch):
     assert timing.total_duration_s == pytest.approx(5.0)
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_pass_timing_report_filters_by_inclusive_threshold():
     timing = TileLangPassTimingInstrument(threshold_ms=10.0)
@@ -145,7 +136,6 @@ def test_pass_timing_report_filters_by_inclusive_threshold():
     assert "Self" in report
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_pass_timing_report_includes_context():
     timing = TileLangPassTimingInstrument()
@@ -156,7 +146,6 @@ def test_pass_timing_report_includes_context():
     assert "Context: stage=grouped-host, config=3, kernel=main_gc_3" in report
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_pass_timing_report_is_emitted_on_failure(monkeypatch):
     timing = TileLangPassTimingInstrument()
@@ -172,15 +161,17 @@ def test_pass_timing_report_is_emitted_on_failure(monkeypatch):
     assert contexts == ["stage=jit-lower, kernel=main"]
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
-def test_pass_timing_cleans_incomplete_frames_after_pass_failure(caplog):
+def test_pass_timing_cleans_incomplete_frames_after_pass_failure(caplog, monkeypatch):
     timing = TileLangPassTimingInstrument()
 
     @tvm.transform.module_pass(opt_level=0, name="FailingPass")
     def failing_pass(mod, ctx):
         raise RuntimeError("expected failure")
 
+    # TileLang's top-level logger normally stops propagation after its custom
+    # handler; enable propagation so pytest's caplog fixture can inspect it.
+    monkeypatch.setattr(logging.getLogger("tilelang"), "propagate", True)
     caplog.set_level(logging.WARNING, logger="tilelang.pass_timing")
     with pytest.raises(RuntimeError, match="expected failure"), tvm.transform.PassContext(instruments=[timing.instrument]):
         failing_pass(_simple_module())
@@ -189,10 +180,10 @@ def test_pass_timing_cleans_incomplete_frames_after_pass_failure(caplog):
     assert "Discarding 1 incomplete pass timing frame" in caplog.text
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
-def test_pass_timing_ignores_unmatched_after_callback(caplog):
+def test_pass_timing_ignores_unmatched_after_callback(caplog, monkeypatch):
     timing = TileLangPassTimingInstrument()
+    monkeypatch.setattr(logging.getLogger("tilelang"), "propagate", True)
     caplog.set_level(logging.WARNING, logger="tilelang.pass_timing")
 
     timing._enter_pass_ctx()

--- a/testing/python/issue/test_tilelang_issue_2554.py
+++ b/testing/python/issue/test_tilelang_issue_2554.py
@@ -5,7 +5,6 @@ import tilelang.language as T
 import tilelang.testing
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_runtime_unknown_sign_vector_negative_index_load():
     @T.prim_func
@@ -32,7 +31,6 @@ def test_runtime_unknown_sign_vector_negative_index_load():
     torch.testing.assert_close(b, expected)
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_runtime_unknown_sign_vector_negative_index_store():
     @T.prim_func

--- a/testing/python/language/test_tilelang_language_reduce.py
+++ b/testing/python/language/test_tilelang_language_reduce.py
@@ -493,9 +493,9 @@ def _make_nan_reduce_kernel(reduce_fn, M, N, dtype, threads, *, nan_propagate):
     return kernel
 
 
-# TODO: new issue for merge main to dev
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(8, 9)
 def test_reduce_packed_fp8_to_float16_absmax_runtime():
     if not hasattr(torch, "float8_e4m3fn"):
         pytest.skip("torch.float8_e4m3fn is not available")

--- a/testing/python/language/test_tilelang_language_tma_copy.py
+++ b/testing/python/language/test_tilelang_language_tma_copy.py
@@ -397,7 +397,7 @@ def run_fp4_tma_copy_roundtrip():
     assert torch.equal(b.view(torch.int8), a)
 
 
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 def test_fp4_unpacksmem_tma_descriptor_uses_align16b():
     program = fp4_tma_copy_unpacked_smem_load()
     artifact = tilelang.lower(
@@ -413,7 +413,7 @@ def test_fp4_unpacksmem_tma_descriptor_uses_align16b():
     assert 'T.call_packed("__tvm_tensormap_create_tiled", A_desc, 14,' in host_ir
 
 
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 def test_fp4_unpacksmem_tma_store_is_rejected():
     program = fp4_tma_copy_unpacked_smem_store()
     with pytest.raises(tvm.TVMError, match="only supports float4_e2m1_unpacked as an FP4 unpack load"):
@@ -424,7 +424,7 @@ def test_fp4_unpacksmem_tma_store_is_rejected():
         )
 
 
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 def test_copy_prefer_tma_lowers_as_synchronous_tma_load():
     @T.prim_func
     def main(x: T.Tensor((128, 32), T.float32)):

--- a/testing/python/language/test_tilelang_language_wgmma_gemm.py
+++ b/testing/python/language/test_tilelang_language_wgmma_gemm.py
@@ -74,19 +74,17 @@ def _make_wgmma_kernel(gemm_op):
     return main
 
 
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_eq(9, 0)
-@pytest.mark.parametrize(
-    "gemm_api",
-    [T.wgmma_gemm],
-)
-def test_wgmma_gemm_has_no_implicit_wait(gemm_api):
-    kernel = tilelang.compile(_make_wgmma_kernel(lambda A, B, C: gemm_api(A, B, C, clear_accum=True)), target="cuda")
+def test_wgmma_gemm_has_no_implicit_wait():
+    kernel = tilelang.compile(_make_wgmma_kernel(lambda A, B, C: T.wgmma_gemm(A, B, C, clear_accum=True)), target="cuda")
     src = kernel.get_kernel_source()
 
     assert src.count("tl::wait_wgmma<0>();") == 1
 
 
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_eq(9, 0)
 def test_wgmma_gemm_dispatch_has_no_implicit_wait():
@@ -98,6 +96,7 @@ def test_wgmma_gemm_dispatch_has_no_implicit_wait():
     assert kernel.get_kernel_source().count("tl::wait_wgmma<0>();") == 1
 
 
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_eq(9, 0)
 def test_wgmma_gemm_rejects_mma_fallback():
@@ -155,6 +154,7 @@ def _make_sliced_wgmma_kernel(M, N, K, num_k_tiles):
     return main
 
 
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_eq(9, 0)
 def test_wgmma_gemm_sliced_operand_emits_offset():
@@ -165,6 +165,7 @@ def test_wgmma_gemm_sliced_operand_emits_offset():
     assert "increase_descriptor_offset" in src
 
 
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_eq(9, 0)
 @pytest.mark.parametrize(

--- a/testing/python/tools/test_tilelang_tools_cuda_iket.py
+++ b/testing/python/tools/test_tilelang_tools_cuda_iket.py
@@ -126,7 +126,7 @@ def test_iket_is_a_cuda_tool_not_a_language_namespace():
     assert iket.__name__ == "tilelang.tools.cuda.iket"
 
 
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
 def test_event_metadata_is_preserved_in_tir_and_injected_source():
     with iket.session():
@@ -143,7 +143,7 @@ def test_event_metadata_is_preserved_in_tir_and_injected_source():
     assert "__iket_range_decl_compute_phase" in source
 
 
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
 def test_float_payload_macro_uses_distinct_temporaries():
     with iket.session(runtime_payloads=True):
@@ -166,7 +166,7 @@ def test_float_payload_macro_uses_distinct_temporaries():
     assert "TL_IKET_EVENT_PAYLOAD_F32" in source
 
 
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
 def test_prebuilt_payload_primfunc_enables_runtime_payloads_during_lowering():
     assert not iket.runtime_payloads_enabled()
@@ -187,7 +187,7 @@ def test_prebuilt_payload_primfunc_enables_runtime_payloads_during_lowering():
     assert _event_metadata_bytes(source, "float_value")[12:16] == [13, 0, 0, 0]
 
 
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize("arch", ["sm_80", "sm_86", "sm_89"])
 def test_cluster_rank_register_is_gated_by_cuda_architecture(arch):
@@ -202,7 +202,7 @@ def test_cluster_rank_register_is_gated_by_cuda_architecture(arch):
     assert "%cluster_ctarank" in sm90_source
 
 
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
 def test_prebuilt_primfunc_keeps_metadata_when_session_resets_registry():
     kernel = _make_mark_kernel("parsed_before_session")
@@ -228,7 +228,7 @@ def test_event_metadata_changes_kernel_cache_identity():
     assert _cache_key(first) != _cache_key(second)
 
 
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
 def test_independently_built_primfuncs_get_module_wide_event_ids():
     first = _make_mark_kernel("module_first").with_attr("global_symbol", "first")
@@ -253,7 +253,7 @@ def test_event_name_limit_is_checked_during_primfunc_construction():
         _make_mark_kernel("界" * 11)
 
 
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
 def test_nested_session_keeps_outer_callback_active():
     with iket.session():
@@ -324,7 +324,7 @@ def test_session_restores_an_absent_callback():
     tvm_ffi.register_global_func(_CUDA_POSTPROC, f=lambda code, _target: code, override=False)
 
 
-@tilelang.testing.pytest.mark.xfail
+@tilelang.testing.skip_on_maca
 @tilelang.testing.requires_cuda
 def test_session_restores_a_previous_callback():
     def previous(code, _target):

--- a/testing/python/transform/test_tilelang_transform_fuse_mbarrier_arrive_expect_tx.py
+++ b/testing/python/transform/test_tilelang_transform_fuse_mbarrier_arrive_expect_tx.py
@@ -27,6 +27,8 @@ def _collect_calls(stmt, op_name: str):
     return calls
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 def test_fuse_simple_tma_expect_arrive():
     @T.prim_func
     def before(A_desc: T.handle("uint8x128", "grid_constant")):
@@ -52,6 +54,8 @@ def test_fuse_simple_tma_expect_arrive():
     assert len(_collect_calls(main.body, "tirx.ptx_arrive_barrier")) == 0
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 def test_fuse_requires_same_barrier():
     @T.prim_func
     def before(A_desc: T.handle("uint8x128", "grid_constant")):
@@ -77,6 +81,8 @@ def test_fuse_requires_same_barrier():
     assert len(_collect_calls(main.body, "tirx.ptx_arrive_barrier")) == 1
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 def test_fuse_inside_warp_specialization_scope():
     @T.prim_func
     def before(A_desc: T.handle("uint8x128", "grid_constant")):

--- a/testing/python/transform/test_tilelang_transform_inject_fence_proxy.py
+++ b/testing/python/transform/test_tilelang_transform_inject_fence_proxy.py
@@ -382,6 +382,8 @@ def test_wgmma_marked_async():
     assert order.index("tl.fence_proxy_async") < order.index("tl.ptx_wgmma_ss")
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_shared_barrier_ops_do_not_trigger_fence_proxy():
     @T.prim_func
@@ -491,6 +493,8 @@ def test_shared_barrier_ops_do_not_trigger_fence_proxy():
     _check(before, after)
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_regression_0219_fence_no_fence_inserted():
     """Regression test copied from `debug/0219_fence/fence.py`.
@@ -835,6 +839,8 @@ def test_regression_0219_fence_no_fence_inserted():
     _check(before, after)
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_ldmatrix_then_wgmma_does_not_inject_fence_proxy():
     """Shared-memory loads (including ldmatrix) do not trigger fence injection."""
@@ -878,6 +884,8 @@ def test_ldmatrix_then_wgmma_does_not_inject_fence_proxy():
     _check(before, before)
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_stmatrix_then_wgmma_injects_fence_proxy():
     @T.prim_func
@@ -954,6 +962,8 @@ def test_stmatrix_then_wgmma_injects_fence_proxy():
     _check(before, after)
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_if_merge_may_be_generic_then_async_injects_fence_proxy():
     @T.prim_func
@@ -1018,6 +1028,8 @@ def test_if_merge_may_be_generic_then_async_injects_fence_proxy():
     _check(before, after)
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_hoist_fence_proxy_out_of_if():
     """Hoist a single fence out of a pure-async if-then-else region."""
@@ -1122,6 +1134,8 @@ def test_hoist_fence_proxy_out_of_if():
     _check(before, after)
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_hoist_fence_proxy_out_of_unrolled_loop():
     """Prefer a single preheader fence over per-iteration fences.
@@ -1195,6 +1209,8 @@ def test_hoist_fence_proxy_out_of_unrolled_loop():
     _check(before, after)
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_hoist_fence_proxy_out_of_while_loop():
     """Hoist a single fence out of a pure-async while-loop body."""
@@ -1267,6 +1283,8 @@ def test_hoist_fence_proxy_out_of_while_loop():
     _check(before, after)
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_loop_carried_generic_then_async_injects_fence_proxy():
     """Generic proxy traffic at the end of an iteration may affect the next iteration."""
@@ -1333,6 +1351,8 @@ def test_loop_carried_generic_then_async_injects_fence_proxy():
     _check(before, after)
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_shared_load_does_not_trigger_fence_proxy():
     """Shared loads are not treated as generic proxy traffic for fence injection."""

--- a/testing/python/transform/test_tilelang_transform_inject_set_max_nreg.py
+++ b/testing/python/transform/test_tilelang_transform_inject_set_max_nreg.py
@@ -35,6 +35,8 @@ def _find_if_with_set_max_nreg(func, then_call, else_call):
     return matches[0]
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 def test_inject_set_max_nreg():
     """Test the InjectSetMaxNReg pass"""
 

--- a/testing/python/transform/test_tilelang_transform_lower_shared_tmem.py
+++ b/testing/python/transform/test_tilelang_transform_lower_shared_tmem.py
@@ -27,6 +27,8 @@ def _collect_calls(stmt, op_name: str):
     return calls
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 def test_explicit_deallocate_tmem_suppresses_auto_dealloc():
     """Explicit T.deallocate_tmem on fallthrough suppresses auto-dealloc."""
 
@@ -46,6 +48,8 @@ def test_explicit_deallocate_tmem_suppresses_auto_dealloc():
     assert dealloc_call.args[1].value == 128
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 def test_explicit_deallocate_only_suppresses_matching_buffer():
     """Only the explicitly-deallocated buffer skips auto-dealloc; others keep it."""
 
@@ -67,6 +71,8 @@ def test_explicit_deallocate_only_suppresses_matching_buffer():
     assert dealloc_num_cols == [64, 128]
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 def test_dealloc_before_thread_return_keeps_auto_dealloc():
     """Dealloc on non-fallthrough path (before thread_return) does NOT suppress auto-dealloc."""
 

--- a/testing/python/transform/test_tilelang_transform_pipeline_planning.py
+++ b/testing/python/transform/test_tilelang_transform_pipeline_planning.py
@@ -2,6 +2,7 @@ from tilelang import tvm as tvm
 import tilelang as tl
 from tilelang.backend.target import determine_target
 import tilelang.language as T
+import tilelang.testing
 from tvm.tirx.stmt_functor import post_order_visit
 
 auto_target = tvm.target.Target(determine_target("auto"))
@@ -258,6 +259,8 @@ def test_pipeline_planning_before_after_mbarrier_arrive_wait_plan():
     _check(before, after, target=sm80_target)
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 def test_pipeline_planning_before_after_tma_copy_plan():
     @T.prim_func
     def before(A: T.Tensor((64,), T.float16), C: T.Tensor((64,), T.float16)):
@@ -314,6 +317,8 @@ def test_pipeline_planning_before_after_tma_copy_plan():
     _check(before, after, target=sm90_target)
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 def test_pipeline_planning_before_after_wgmma_gemm_plan():
     @T.prim_func
     def before(
@@ -388,6 +393,8 @@ def test_pipeline_planning_before_after_wgmma_gemm_plan():
     _check(before, after, target=sm90_target)
 
 
+@tilelang.testing.skip_on_maca
+@tilelang.testing.requires_cuda
 def test_pipeline_planning_before_after_tcgen05_gemm_plan():
     @T.prim_func
     def before(

--- a/tilelang/maca/language/__init__.py
+++ b/tilelang/maca/language/__init__.py
@@ -4,16 +4,13 @@ from __future__ import annotations
 
 from tilelang.language.common import *  # noqa: F401,F403
 from tilelang.language.common import __all__ as _COMMON_ALL
-from tilelang.language.allocate import alloc_cluster_barrier, alloc_descriptor, alloc_tmem  # noqa: F401
 from tilelang.language.annotations import annotate_l2_hit_ratio, annotate_min_blocks_per_sm  # noqa: F401
 from tilelang.language.builtin import (  # noqa: F401
     annotate_consumer_reg_alloc,
     annotate_producer_reg_dealloc,
-    create_tma_descriptor,
     deallocate_tmem,
     dec_max_nreg,
     disable_warp_group_reg_alloc,
-    fence_proxy_async,
     get_warp_group_idx,
     inc_max_nreg,
     increase_descriptor_offset,
@@ -26,9 +23,6 @@ from tilelang.language.builtin import (  # noqa: F401
     lds64,
     match_all_sync,
     match_any_sync,
-    named_barrier_arrive,
-    ptx_arrive_cluster_barrier,
-    ptx_mma_sm70,
     set_max_nreg,
     shuffle_elect,
     stg128,
@@ -38,16 +32,10 @@ from tilelang.language.builtin import (  # noqa: F401
     sts128,
     sts32,
     sts64,
-    tma_load,
-    tma_load_2sm,
-    tma_store_arrive,
-    tma_store_wait,
 )
-from tilelang.language.copy_op import copy_cluster, tma_copy, tma_gather4, tma_gather4_bytes, tma_scatter4  # noqa: F401
-from tilelang.language.kernel import ClusterKernel, CUDASourceCodeKernel  # noqa: F401
+from tilelang.language.copy_op import maca_async_copy  # noqa: F401
+from tilelang.language.kernel import CUDASourceCodeKernel  # noqa: F401
 
-from .cluster import *  # noqa: F401,F403
-from .cluster import __all__ as _CLUSTER_ALL
 from .intrinsics import *  # noqa: F401,F403
 from .intrinsics import __all__ as _INTRINSICS_ALL
 from .pdl import *  # noqa: F401,F403
@@ -62,21 +50,14 @@ from .warpgroup import *  # noqa: F401,F403
 from .warpgroup import __all__ as _WARPGROUP_ALL
 
 _MACA_API_ALL = (
-    "ClusterKernel",
     "CUDASourceCodeKernel",
-    "alloc_cluster_barrier",
-    "alloc_descriptor",
-    "alloc_tmem",
     "annotate_consumer_reg_alloc",
     "annotate_l2_hit_ratio",
     "annotate_min_blocks_per_sm",
     "annotate_producer_reg_dealloc",
-    "copy_cluster",
-    "create_tma_descriptor",
     "deallocate_tmem",
     "dec_max_nreg",
     "disable_warp_group_reg_alloc",
-    "fence_proxy_async",
     "get_warp_group_idx",
     "inc_max_nreg",
     "increase_descriptor_offset",
@@ -89,9 +70,6 @@ _MACA_API_ALL = (
     "lds64",
     "match_all_sync",
     "match_any_sync",
-    "named_barrier_arrive",
-    "ptx_arrive_cluster_barrier",
-    "ptx_mma_sm70",
     "set_max_nreg",
     "shuffle_elect",
     "stg128",
@@ -101,14 +79,7 @@ _MACA_API_ALL = (
     "sts128",
     "sts32",
     "sts64",
-    "tma_copy",
-    "tma_gather4",
-    "tma_gather4_bytes",
-    "tma_load",
-    "tma_load_2sm",
-    "tma_scatter4",
-    "tma_store_arrive",
-    "tma_store_wait",
+    "maca_async_copy",
 )
 
 __tilelang_dialect__ = "maca"
@@ -117,7 +88,6 @@ __all__ = tuple(
         (
             *_COMMON_ALL,
             *_MACA_API_ALL,
-            *_CLUSTER_ALL,
             *_INTRINSICS_ALL,
             *_PDL_ALL,
             *_PRINT_ALL,
@@ -128,4 +98,4 @@ __all__ = tuple(
     )
 )
 
-del _CLUSTER_ALL, _COMMON_ALL, _MACA_API_ALL, _INTRINSICS_ALL, _PDL_ALL, _PRINT_ALL, _RANDOM_ALL, _TIR_ALL, _WARPGROUP_ALL
+del _COMMON_ALL, _MACA_API_ALL, _INTRINSICS_ALL, _PDL_ALL, _PRINT_ALL, _RANDOM_ALL, _TIR_ALL, _WARPGROUP_ALL

--- a/tilelang/maca/language/intrinsics.py
+++ b/tilelang/maca/language/intrinsics.py
@@ -9,56 +9,11 @@ from tilelang.maca.intrinsics import (
     mma_store_index_map,
 )
 from tilelang.maca.intrinsics.macro.mma_sp_macro_generator import SparseTensorCoreIntrinEmitter
-from tilelang.language.allocate import (
-    alloc_tcgen05_instr_desc,
-    alloc_tcgen05_instruction_desc,
-    alloc_tcgen05_smem_desc,
-    alloc_wgmma_desc,
-)
 from tilelang.language.builtin import (
     __ffs,
     __fns,
     __ldg,
-    cp_async_barrier_noinc,
-    initialize_tcgen05_descriptor,
-    initialize_wgmma_descriptor,
-    tcgen05_after_thread_sync,
-    tcgen05_before_thread_sync,
-    tcgen05_cp_warpx4,
-    tcgen05_mma_arrive,
-    tcgen05_sf_warp_transpose,
-    wait_wgmma,
-    warpgroup_arrive,
-    warpgroup_commit_batch,
-    warpgroup_fence_operand,
-    warpgroup_wait,
 )
-from tilelang.language.experimental.gemm_sp_op import tcgen05_gemm_sp, wgmma_gemm_sp
-from tilelang.language.gemm_op import (
-    make_blockscaled_gemm_layout,
-    tcgen05_gemm,
-    tcgen05_gemm_blockscaled,
-    wgmma_gemm,
-)
-from .tir import (
-    ptx_cp_async,
-    ptx_cp_async_barrier,
-    ptx_cp_async_bulk,
-    ptx_ldmatrix,
-    ptx_mma,
-    ptx_mma_sp,
-    ptx_tcgen05_mma_blockscaled_ss,
-    ptx_tcgen05_mma_ss,
-    ptx_tcgen05_mma_ts,
-    ptx_wgmma_rs,
-    ptx_wgmma_sp_rs,
-    ptx_wgmma_sp_ss,
-    ptx_wgmma_ss,
-)
-
-tcgen05_mma = tcgen05_gemm
-tcgen05_mma_blockscaled = tcgen05_gemm_blockscaled
-wgmma_mma = wgmma_gemm
 
 __all__ = [
     "SparseTensorCoreIntrinEmitter",
@@ -66,46 +21,7 @@ __all__ = [
     "__ffs",
     "__fns",
     "__ldg",
-    "alloc_tcgen05_instr_desc",
-    "alloc_tcgen05_instruction_desc",
-    "alloc_tcgen05_smem_desc",
-    "alloc_wgmma_desc",
-    "cp_async_barrier_noinc",
     "device_assert",
-    "initialize_tcgen05_descriptor",
-    "initialize_wgmma_descriptor",
-    "make_blockscaled_gemm_layout",
     "make_mma_swizzle_layout",
     "mma_store_index_map",
-    "ptx_cp_async",
-    "ptx_cp_async_barrier",
-    "ptx_cp_async_bulk",
-    "ptx_ldmatrix",
-    "ptx_mma",
-    "ptx_mma_sp",
-    "ptx_tcgen05_mma_blockscaled_ss",
-    "ptx_tcgen05_mma_ss",
-    "ptx_tcgen05_mma_ts",
-    "ptx_wgmma_rs",
-    "ptx_wgmma_sp_rs",
-    "ptx_wgmma_sp_ss",
-    "ptx_wgmma_ss",
-    "tcgen05_after_thread_sync",
-    "tcgen05_before_thread_sync",
-    "tcgen05_cp_warpx4",
-    "tcgen05_gemm",
-    "tcgen05_gemm_blockscaled",
-    "tcgen05_gemm_sp",
-    "tcgen05_mma",
-    "tcgen05_mma_arrive",
-    "tcgen05_mma_blockscaled",
-    "tcgen05_sf_warp_transpose",
-    "wait_wgmma",
-    "warpgroup_arrive",
-    "warpgroup_commit_batch",
-    "warpgroup_fence_operand",
-    "warpgroup_wait",
-    "wgmma_gemm",
-    "wgmma_gemm_sp",
-    "wgmma_mma",
 ]

--- a/tilelang/maca/language/tir.py
+++ b/tilelang/maca/language/tir.py
@@ -1,17 +1,9 @@
 """MACA-specific low-level TIR language operators."""
 
 import tilelang.language.tir.op as _tir_op
-from tilelang.language.tir.exports import CUDA_ONLY_TIR_EXPORTS, SHARED_LEGACY_TIR_EXPORTS, MACA_ONLY_TIR_EXPORTS
+from tilelang.language.tir.exports import MACA_ONLY_TIR_EXPORTS
 from tilelang.language.tir.ir import (
     _dtype_forward,
-    _op_wrapper,
-    ptx_arrive_barrier as ptx_arrive_barrier,
-    ptx_arrive_barrier_expect_tx as ptx_arrive_barrier_expect_tx,
-    ptx_commit_group as ptx_commit_group,
-    ptx_cp_async as ptx_cp_async,
-    ptx_cp_async_barrier as ptx_cp_async_barrier,
-    ptx_init_barrier_thread_count as ptx_init_barrier_thread_count,
-    ptx_wait_group as ptx_wait_group,
 )
 
 tvm_mfma = _dtype_forward(_tir_op.tvm_mfma)
@@ -19,18 +11,5 @@ tvm_mfma_store = _dtype_forward(_tir_op.tvm_mfma_store)
 tvm_rdna_wmma = _dtype_forward(_tir_op.tvm_rdna_wmma)
 tvm_rdna_wmma_store = _dtype_forward(_tir_op.tvm_rdna_wmma_store)
 
-ptx_cp_async_bulk = _dtype_forward(_tir_op.ptx_cp_async_bulk)
-ptx_fence_barrier_init = _op_wrapper(_tir_op.ptx_fence_barrier_init)
-ptx_ldmatrix = _dtype_forward(_tir_op.ptx_ldmatrix)
-ptx_mma = _dtype_forward(_tir_op.ptx_mma)
-ptx_mma_sp = _dtype_forward(_tir_op.ptx_mma_sp)
-ptx_tcgen05_mma_blockscaled_ss = _dtype_forward(_tir_op.ptx_tcgen05_mma_blockscaled_ss)
-ptx_tcgen05_mma_ss = _dtype_forward(_tir_op.ptx_tcgen05_mma_ss)
-ptx_tcgen05_mma_ts = _dtype_forward(_tir_op.ptx_tcgen05_mma_ts)
-ptx_wait_barrier = _op_wrapper(_tir_op.ptx_wait_barrier)
-ptx_wgmma_rs = _dtype_forward(_tir_op.ptx_wgmma_rs)
-ptx_wgmma_sp_rs = _dtype_forward(_tir_op.ptx_wgmma_sp_rs)
-ptx_wgmma_sp_ss = _dtype_forward(_tir_op.ptx_wgmma_sp_ss)
-ptx_wgmma_ss = _dtype_forward(_tir_op.ptx_wgmma_ss)
 
-__all__ = tuple(sorted(MACA_ONLY_TIR_EXPORTS | CUDA_ONLY_TIR_EXPORTS | SHARED_LEGACY_TIR_EXPORTS))
+__all__ = tuple(sorted(MACA_ONLY_TIR_EXPORTS))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Simplified the WGMMA no-implicit-wait test by removing redundant parameterization.
- Added CUDA requirements and Maca/macOS skip markers to CUDA-specific tests.
- Reclassified non-functional or unsupported tests by removing unnecessary `xfail` markers and using platform or capability skips.
- Reduced the MACA language and TIR APIs to supported exports.
- Added `maca_async_copy` to the MACA language exports.
- Added packed FP4 and 4-bit integer code generation support.
- Added MACA vector compatibility macros and `float2` reduction functors.

## Testing

- Updated tests to run only on supported CUDA platforms and compute capabilities.
- Removed expected-failure markers from tests that now run normally.

## C++ style / lint notes

- The PR changes C++ code but does not modify `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) remains advisory.
- No correctness or build issues are identified from the C++ changes. Warning-only style findings should not block the merge unless they indicate an API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->