### PR TITLE
[MetaxGPU][testing]fix test_tilelang_langguage_vectorized_cast.py xfail

### DIFF
--- a/src/maca/target_utils.cc
+++ b/src/maca/target_utils.cc
@@ -78,6 +78,22 @@ bool IsMacaVectorizableCast(DataType from_ty, DataType target_ty) {
       target_ty.bits() == 32)
     return true;
 
+  // float8 (E4M3/E5M2) -> float16
+  if (IsMacaVectorizableFP8(from_ty) && target_ty.is_float16())
+    return true;
+
+  // float8 (E4M3/E5M2) -> bfloat16
+  if (IsMacaVectorizableFP8(from_ty) && target_ty.is_bfloat16())
+    return true;
+
+  // float16 -> float8 (E4M3/E5M2)
+  if (from_ty.is_float16() && IsMacaVectorizableFP8(target_ty))
+    return true;
+
+  // bfloat16 -> float8 (E4M3/E5M2)
+  if (from_ty.is_bfloat16() && IsMacaVectorizableFP8(target_ty))
+    return true;
+
   // Not implemented for now
 
   // float64(double) -> float8 (E4M3/E5M2)

--- a/src/tl_templates/maca/maca_fp8.h
+++ b/src/tl_templates/maca/maca_fp8.h
@@ -4,36 +4,52 @@
 #include <maca_fp8.h>
 
 TL_DEVICE half_t __cvt_fp8_e4m3_to_half(__maca_fp8_e4m3 x) {
-  uint16_t bits = (uint16_t)x.__x;
-  bits = (uint16_t)(bits << 8U);
+  unsigned char bits = x.__x;
+  uint16_t sign = (bits & 0x80) ? 0x8000U : 0U;
+  uint16_t exp4 = (bits >> 3) & 0x0FU;
+  uint16_t man3 = bits & 0x07U;
 
-  uint16_t sign = bits & 0x8000U;
-  uint16_t exponent = (uint16_t)(((bits & 0x7800U) >> 1U) + 0x2000U);
-  uint16_t mantissa = (bits & 0x0700U) >> 1U;
-  unsigned char absx = 0x7FU & (unsigned char)x.__x;
-
-  if (absx == 0x7FU) { // NaN
-    bits = 0x7FFFU;    // fp16 canonical NaN, discard sign
-  } else if (exponent == 0x2000U) {
-    // zero or denormal
-    if (mantissa != 0U) {
-      // normalize
-      mantissa = (uint16_t)(mantissa << 1U);
-      while ((mantissa & 0x0400U) == 0U) {
-        mantissa = (uint16_t)(mantissa << 1U);
-        exponent = (uint16_t)(exponent - 0x0400U);
-      }
-      // discard implicit leading bit
-      mantissa &= 0x03FFU;
-    } else { // Zero
-      exponent = 0U;
-    }
-    bits = (sign | exponent) | mantissa;
-  } else {
-    bits = (sign | exponent) | mantissa;
+  // NaN: E4M3FN encodes NaN as 0x7F (exp=15, mant=7)
+  if ((bits & 0x7F) == 0x7F) {
+    uint16_t nan_bits = 0x7FFFU;
+    return *reinterpret_cast<half_t *>(&nan_bits);
   }
 
-  return *reinterpret_cast<half_t *>(&bits);
+  uint16_t fp16_bits;
+
+  if (exp4 == 0) {
+    // Zero or denormal E4M3
+    if (man3 == 0) {
+      fp16_bits = sign; // Zero
+    } else {
+      // E4M3 denormal: value = man3 * 2^-9
+      // Convert to FP16: man3 * 64 = 2^exp16 * (1 + man16/1024)
+      uint16_t scale = man3 << 6;
+
+      int msb_pos = 0;
+      uint16_t temp = scale;
+      while (temp > 1) {
+        temp >>= 1;
+        msb_pos++;
+      }
+
+      uint16_t fp16_exp = msb_pos;
+      uint16_t fp16_man = ((scale - (1U << msb_pos)) * 1024) >> msb_pos;
+      fp16_bits = sign | (fp16_exp << 10) | (fp16_man & 0x03FF);
+    }
+  } else {
+    // Normal E4M3: exp16 = exp4 + 8, man16 = man3 << 7
+    uint16_t fp16_exp = exp4 + 8;
+    uint16_t fp16_man = man3 << 7;
+
+    if (fp16_exp >= 31) {
+      fp16_bits = sign | 0x7C00U; // FP16 infinity
+    } else {
+      fp16_bits = sign | (fp16_exp << 10) | fp16_man;
+    }
+  }
+
+  return *reinterpret_cast<half_t *>(&fp16_bits);
 }
 
 TL_DEVICE float __cvt_fp8_e4m3_to_float(__maca_fp8_e4m3 x) {
@@ -625,19 +641,321 @@ __tl_cvt_fp8x2_to_float2(const __maca_fp8x2_storage_t x,
 }
 
 // e4m3x2 -> half2
+// Software implementation for E4M3FN to ensure correct denormal handling
 TL_DEVICE half2
 __tl_cvt_fp8x2_to_half2(const __maca_fp8x2_storage_t x,
                         const __maca_fp8_interpretation_t fp8_interpretation) {
-  __half2_raw raw = __maca_cvt_fp8x2_to_halfraw2(x, fp8_interpretation);
+  // Extract low and high bytes
+  const unsigned char lo = static_cast<unsigned char>(x & 0xff);
+  const unsigned char hi = static_cast<unsigned char>((x >> 8) & 0xff);
+
+  // Helper: E4M3 -> FP16 bits
+  auto cvt_e4m3_bits = [](unsigned char bits) -> uint16_t {
+    uint16_t sign = (bits & 0x80) ? 0x8000U : 0U;
+    uint16_t exp4 = (bits >> 3) & 0x0FU;
+    uint16_t man3 = bits & 0x07U;
+
+    if ((bits & 0x7F) == 0x7F) {
+      return 0x7FFFU; // FP16 canonical NaN
+    }
+
+    if (exp4 == 0) {
+      if (man3 == 0) {
+        return sign;
+      }
+      uint16_t scale = man3 << 6;
+      int msb_pos = 0;
+      uint16_t temp = scale;
+      while (temp > 1) {
+        temp >>= 1;
+        msb_pos++;
+      }
+      uint16_t fp16_exp = msb_pos;
+      uint16_t fp16_man = ((scale - (1U << msb_pos)) * 1024) >> msb_pos;
+      return sign | (fp16_exp << 10) | (fp16_man & 0x03FF);
+    }
+
+    uint16_t fp16_exp = exp4 + 8;
+    uint16_t fp16_man = man3 << 7;
+    if (fp16_exp >= 31) {
+      return sign | 0x7C00U;
+    }
+    return sign | (fp16_exp << 10) | fp16_man;
+  };
+
+  // Helper: E5M2 -> FP16 bits (simple bit manipulation, SDK is correct for
+  // E5M2)
+  auto cvt_e5m2_bits = [](unsigned char bits) -> uint16_t {
+    uint16_t sign = (bits & 0x80) ? 0x8000U : 0U;
+    uint16_t be = static_cast<uint16_t>(bits) << 8;
+    uint16_t exponent = be & 0x7C00U;
+    uint16_t mantissa = be & 0x0300U;
+    if (exponent == 0x7C00U && mantissa != 0) {
+      mantissa |= 0x0200U; // Quiet NaN
+    }
+    return sign | exponent | mantissa;
+  };
+
+  __half2_raw raw;
+  if (fp8_interpretation == __MACA_E4M3) {
+    raw.x = cvt_e4m3_bits(lo);
+    raw.y = cvt_e4m3_bits(hi);
+  } else {
+    raw.x = cvt_e5m2_bits(lo);
+    raw.y = cvt_e5m2_bits(hi);
+  }
   return *reinterpret_cast<half2 *>(&raw);
 }
 
-// half2 -> e4m3x2
+// Helper: Convert a single FP16 (as uint16_t bits) to E4M3FN byte.
+// This follows the standard E4M3FN specification compatible with PyTorch:
+// - No infinities (saturate to max finite value)
+// - NaN encoded as 0x7F (exponent=15, mantissa=7)
+// - Round-to-nearest-even rounding
+static TL_DEVICE unsigned char __tl_cvt_half_bits_to_e4m3_fn(uint16_t h) {
+  const uint16_t sign = h & 0x8000U;
+  const uint16_t exp_h = (h >> 10) & 0x1FU;
+  const uint16_t man_h = h & 0x03FFU;
+
+  // Handle zero and denormals in FP16
+  if (exp_h == 0) {
+    // FP16 denormal/zero -> FP8 denormal/zero (with possible underflow to zero)
+    // FP16 denormal range: 2^-24 to 2^-15 * (2 - 2^-10)
+    // FP8 E4M3 denormal range: 2^-9 to 2^-7 * (1 + 7/8)
+    // Very small FP16 denormals underflow to FP8 zero
+    if (man_h == 0) {
+      return static_cast<unsigned char>(sign >> 8); // Preserve sign of zero
+    }
+    // FP16 denormal to float, then convert
+    // This is slow but correct for edge cases
+    float f = __half2float(*reinterpret_cast<const half *>(&h));
+    // Convert via float
+    uint32_t bits = *reinterpret_cast<uint32_t *>(&f);
+    uint32_t sign_f = bits & 0x80000000U;
+    int32_t exp_f = static_cast<int32_t>((bits >> 23) & 0xFF) - 127;
+    uint32_t man_f = bits & 0x007FFFFFU;
+
+    if (exp_f < -9) {
+      // Underflow to zero
+      return static_cast<unsigned char>(sign >> 8);
+    }
+    // Compute E4M3 representation
+    // Target: value = (-1)^s * 2^(exp4-7) * (1 + man3/8)
+    int exp4 = exp_f + 7;
+    uint32_t man3 = (man_f >> 20) & 0x7; // Take top 3 bits of mantissa
+    // Handle rounding for denormals
+    uint32_t round_bit = (man_f >> 19) & 1;
+    uint32_t sticky = (man_f & 0x7FFFF) != 0 ? 1 : 0;
+    if (round_bit && (sticky || (man3 & 1))) {
+      man3++;
+      if (man3 > 7) {
+        man3 = 0;
+        exp4++;
+      }
+    }
+    if (exp4 <= 0) {
+      return static_cast<unsigned char>(sign >> 8);
+    }
+    if (exp4 >= 15) {
+      // Saturate to max finite value (no infinity in E4M3FN)
+      return static_cast<unsigned char>((sign >> 8) | 0x7E);
+    }
+    return static_cast<unsigned char>((sign >> 8) | ((exp4 << 3) & 0x78) |
+                                      man3);
+  }
+
+  // Handle infinity/NaN in FP16
+  if (exp_h == 31) {
+    if (man_h == 0) {
+      // FP16 infinity -> saturate to max finite E4M3FN value
+      return static_cast<unsigned char>((sign >> 8) | 0x7E);
+    }
+    // FP16 NaN -> E4M3FN NaN (0x7F)
+    return 0x7F;
+  }
+
+  // Normal FP16 number
+  // FP16: value = (-1)^s * 2^(exp_h-15) * (1 + man_h/1024)
+  // E4M3FN: value = (-1)^s * 2^(exp4-7) * (1 + man3/8)
+  // exp4 = exp_h - 15 + 7 = exp_h - 8
+  int exp4 = static_cast<int>(exp_h) - 8;
+
+  if (exp4 <= 0) {
+    // Underflow: try to represent as denormal or zero
+    // E4M3FN denormal range: 2^-9 to 2^-7 * (1 + 7/8)
+    // Denormal E4M3FN uses effective exponent of -8 (exp4=0)
+    // Value = man3/8 * 2^-9 = man3 * 2^-12
+    // FP16 value = 2^(exp_h-15) * (1 + man_h/1024)
+
+    if (exp_h < 4) {
+      // Too small to represent even as denormal, round to zero
+      return static_cast<unsigned char>(sign >> 8);
+    }
+
+    // Convert to denormal E4M3
+    // We need: man3/8 * 2^-9 = 2^(exp_h-15) * (1 + man_h/1024)
+    // man3 = (1 + man_h/1024) * 2^(exp_h-15+9) * 8
+    //      = (1024 + man_h) * 2^(exp_h-15+9-10) = (1024 + man_h) * 2^(exp_h-16)
+    // But for exp_h=6: man3 = (1024 + man_h) * 2^-10 = (1024 + man_h) / 1024 ≈
+    // 1 For exp_h=7: man3 = (1024 + man_h) / 512 ≈ 2-4 So we need to shift
+    // right by (16 - exp_h) bits to get mantissa
+
+    int shift_right =
+        16 - static_cast<int>(exp_h); // Number of bits to shift right
+    // Extended mantissa: 11 bits (implicit 1 + 10 explicit)
+    uint32_t extended_m = (1U << 10) | man_h;
+    // We need 3 bits + guard bits for rounding
+    // Shift right to get the final 3-bit mantissa
+    uint32_t shifted =
+        extended_m >> (shift_right - 1); // Keep 1 extra bit for rounding
+
+    uint32_t man3 = (shifted >> 1) & 0x7;
+    uint32_t guard_bit = shifted & 1;
+    uint32_t sticky =
+        (extended_m & ((1U << (shift_right - 1)) - 1)) != 0 ? 1 : 0;
+
+    // Round to nearest even
+    if (guard_bit && (sticky || (man3 & 1))) {
+      man3++;
+      if (man3 > 7) {
+        // Rounding caused overflow to normal number
+        exp4 = 1;
+        man3 = 0;
+        if (exp4 >= 15) {
+          return static_cast<unsigned char>((sign >> 8) | 0x7E);
+        }
+        return static_cast<unsigned char>((sign >> 8) | ((exp4 << 3) & 0x78) |
+                                          man3);
+      }
+    }
+
+    return static_cast<unsigned char>((sign >> 8) | man3);
+  }
+
+  // Normal case: exp4 >= 1
+  // Need to convert mantissa from 10 bits to 3 bits with rounding
+  uint32_t man3 = (man_h >> 7) & 0x7; // Top 3 bits
+  uint32_t round_bit = (man_h >> 6) & 1;
+  uint32_t sticky = (man_h & 0x3F) != 0 ? 1 : 0;
+
+  // Round to nearest even
+  if (round_bit && (sticky || (man3 & 1))) {
+    man3++;
+    if (man3 > 7) {
+      man3 = 0;
+      exp4++;
+    }
+  }
+
+  // Check for overflow after rounding
+  if (exp4 >= 15) {
+    // Saturate to max finite value (no infinity in E4M3FN)
+    return static_cast<unsigned char>((sign >> 8) | 0x7E);
+  }
+
+  return static_cast<unsigned char>((sign >> 8) | ((exp4 << 3) & 0x78) | man3);
+}
+
+// Helper: Convert a single FP16 (as uint16_t bits) to E5M2 byte.
+// E5M2 format: 1 sign, 5 exp, 2 mantissa (same bias as FP16 = 15)
+// - Has infinities and NaN
+// - Round-to-nearest-even rounding
+static TL_DEVICE unsigned char __tl_cvt_half_bits_to_e5m2(uint16_t h) {
+  const uint16_t sign = h & 0x8000U;
+  const uint16_t exp_h = (h >> 10) & 0x1FU;
+  const uint16_t man_h = h & 0x03FFU;
+
+  // Handle zero and denormals in FP16
+  if (exp_h == 0) {
+    // FP16 denormal/zero -> FP8 E5M2 denormal/zero
+    // E5M2 denormal: value = man2 * 2^-16 (exp=0)
+    // FP16 denormal: value = man10 * 2^-24
+    if (man_h == 0) {
+      return static_cast<unsigned char>(sign >> 8); // Zero
+    }
+    // FP16 denormal values are very small, most will underflow to E5M2 zero
+    // E5M2 denormal range: 2^-16 to 2^-15 * (1 + 3/4) ≈ 2^-16 to 1.75*2^-15
+    // FP16 denormal range: 2^-24 to ~2^-15
+    // Only FP16 denormals with value >= 2^-16 can be represented
+    // That means man_h * 2^-24 >= 2^-16 -> man_h >= 2^8 = 256
+    if (man_h < 256) {
+      // Underflow to zero
+      return static_cast<unsigned char>(sign >> 8);
+    }
+    // Convert FP16 denormal to E5M2 denormal
+    // value = man_h * 2^-24 = man2 * 2^-16
+    // man2 = man_h * 2^-8 = man_h >> 8
+    // But we need to round properly
+    uint32_t man2 = man_h >> 8;
+    uint32_t round_bit = (man_h >> 7) & 1;
+    uint32_t sticky = (man_h & 0x7F) != 0 ? 1 : 0;
+    if (round_bit && (sticky || (man2 & 1))) {
+      man2++;
+      if (man2 > 3) {
+        man2 = 0;
+        // Would become normal with exp=1
+        return static_cast<unsigned char>((sign >> 8) | (1 << 2));
+      }
+    }
+    return static_cast<unsigned char>((sign >> 8) | man2);
+  }
+
+  // Handle infinity/NaN in FP16
+  if (exp_h == 31) {
+    if (man_h == 0) {
+      // FP16 infinity -> E5M2 infinity (exp=31, mant=0)
+      return static_cast<unsigned char>((sign >> 8) | 0x7C);
+    }
+    // FP16 NaN -> E5M2 NaN (exp=31, mant!=0)
+    return static_cast<unsigned char>((sign >> 8) | 0x7D); // Quiet NaN
+  }
+
+  // Normal FP16 number
+  // FP16: value = (-1)^s * 2^(exp_h-15) * (1 + man_h/1024)
+  // E5M2: value = (-1)^s * 2^(exp5-15) * (1 + man2/4)
+  // Since bias is the same, exp5 = exp_h for normal numbers
+  // man2 = man_h >> 8 (take top 2 bits of mantissa)
+  uint32_t exp5 = exp_h;
+  uint32_t man2 = (man_h >> 8) & 0x3;
+  uint32_t round_bit = (man_h >> 7) & 1;
+  uint32_t sticky = (man_h & 0x7F) != 0 ? 1 : 0;
+
+  // Round to nearest even
+  if (round_bit && (sticky || (man2 & 1))) {
+    man2++;
+    if (man2 > 3) {
+      man2 = 0;
+      exp5++;
+    }
+  }
+
+  // Check for overflow
+  if (exp5 >= 31) {
+    // Overflow to infinity
+    return static_cast<unsigned char>((sign >> 8) | 0x7C);
+  }
+
+  return static_cast<unsigned char>((sign >> 8) | ((exp5 << 2) & 0x7C) | man2);
+}
+
+// half2 -> fp8x2 (software implementation for E4M3FN and E5M2 compatibility)
 TL_DEVICE __maca_fp8x2_storage_t __tl_cvt_half2_to_fp8x2(
     const half2 src, const __maca_fp8_interpretation_t fp8_interpretation) {
   __half2_raw raw = *reinterpret_cast<const __half2_raw *>(&src);
-  return __maca_cvt_halfraw2_to_fp8x2(raw, __MACA_SATFINITE,
-                                      fp8_interpretation);
+
+  if (fp8_interpretation == __MACA_E4M3) {
+    // Use software conversion for E4M3FN to match PyTorch semantics
+    unsigned char lo = __tl_cvt_half_bits_to_e4m3_fn(raw.x);
+    unsigned char hi = __tl_cvt_half_bits_to_e4m3_fn(raw.y);
+    return static_cast<__maca_fp8x2_storage_t>(lo) |
+           (static_cast<__maca_fp8x2_storage_t>(hi) << 8);
+  } else {
+    // E5M2: also use software conversion for consistency
+    unsigned char lo = __tl_cvt_half_bits_to_e5m2(raw.x);
+    unsigned char hi = __tl_cvt_half_bits_to_e5m2(raw.y);
+    return static_cast<__maca_fp8x2_storage_t>(lo) |
+           (static_cast<__maca_fp8x2_storage_t>(hi) << 8);
+  }
 }
 
 // Scalar fp8 -> half (native MACA intrinsic; single cvt on supported HW).
@@ -648,11 +966,16 @@ __tl_cvt_fp8_to_half(const __maca_fp8_storage_t x,
   return *reinterpret_cast<half *>(&raw);
 }
 
-// Scalar half -> fp8 (native MACA intrinsic; single cvt on supported HW).
+// Scalar half -> fp8 (software implementation for E4M3FN and E5M2
+// compatibility).
 TL_DEVICE __maca_fp8_storage_t __tl_cvt_half_to_fp8(
     const half src, const __maca_fp8_interpretation_t fp8_interpretation) {
   __half_raw raw = *reinterpret_cast<const __half_raw *>(&src);
-  return __maca_cvt_halfraw_to_fp8(raw, __MACA_SATFINITE, fp8_interpretation);
+  if (fp8_interpretation == __MACA_E4M3) {
+    return __tl_cvt_half_bits_to_e4m3_fn(raw.x);
+  } else {
+    return __tl_cvt_half_bits_to_e5m2(raw.x);
+  }
 }
 
 // Scalar bfloat16 -> fp8 (native MACA intrinsic; single cvt on supported HW).

--- a/testing/python/language/test_tilelang_language_vectorized_cast.py
+++ b/testing/python/language/test_tilelang_language_vectorized_cast.py
@@ -96,9 +96,6 @@ def test_vectorized_cast(src_dtype, dst_dtype, check_str, lanes):
     run_vectorized_cast(src_dtype, dst_dtype, check_str, lanes)
 
 
-_X_FAIL_FLOAT_TO_HALF = pytest.mark.xfail(reason="MACA kernel did not call the corresponding function")
-
-
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
     "src_dtype, dst_dtype, check_str, lanes",
@@ -113,12 +110,12 @@ _X_FAIL_FLOAT_TO_HALF = pytest.mark.xfail(reason="MACA kernel did not call the c
         (T.float8_e5m2, T.float32, "__tl_cvt_fp8x2_to_float2", 2),
         (T.float8_e5m2, T.float32, "__tl_cvt_fp8x2_to_float2", 4),
         # FP8 <-> Half
-        pytest.param(T.float8_e4m3fn, T.float16, "__tl_cvt_fp8x2_to_half2", 2, marks=_X_FAIL_FLOAT_TO_HALF),
-        pytest.param(T.float8_e4m3fn, T.float16, "__tl_cvt_fp8x2_to_half2", 4, marks=_X_FAIL_FLOAT_TO_HALF),
-        pytest.param(T.float8_e5m2, T.float16, "__tl_cvt_fp8x2_to_half2", 2, marks=_X_FAIL_FLOAT_TO_HALF),
-        pytest.param(T.float16, T.float8_e4m3fn, "__tl_cvt_half2_to_fp8x2", 2, marks=_X_FAIL_FLOAT_TO_HALF),
-        pytest.param(T.float16, T.float8_e4m3fn, "__tl_cvt_half2_to_fp8x2", 4, marks=_X_FAIL_FLOAT_TO_HALF),
-        pytest.param(T.float16, T.float8_e5m2, "__tl_cvt_half2_to_fp8x2", 2, marks=_X_FAIL_FLOAT_TO_HALF),
+        pytest.param(T.float8_e4m3fn, T.float16, "__tl_cvt_fp8x2_to_half2", 2),
+        pytest.param(T.float8_e4m3fn, T.float16, "__tl_cvt_fp8x2_to_half2", 4),
+        pytest.param(T.float8_e5m2, T.float16, "__tl_cvt_fp8x2_to_half2", 2),
+        pytest.param(T.float16, T.float8_e4m3fn, "__tl_cvt_half2_to_fp8x2", 2),
+        pytest.param(T.float16, T.float8_e4m3fn, "__tl_cvt_half2_to_fp8x2", 4),
+        pytest.param(T.float16, T.float8_e5m2, "__tl_cvt_half2_to_fp8x2", 2),
         # E8M0 <-> BFloat16
         (T.float8_e8m0fnu, T.bfloat16, "__tl_cvt_e8m0x2_to_bfloat162", 2),
         (T.bfloat16, T.float8_e8m0fnu, "__tl_cvt_bfloat162_to_e8m0x2", 2),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added vectorizable cast support for FP8 E4M3/E5M2 conversions with `float16` and `bfloat16`.
- Reworked FP8 conversion helpers with explicit handling for rounding, underflow, overflow, NaN, infinity, zero, denormal, and saturation cases.
- Removed the FP8↔FP16 test xfail marker so the tests run as normal.
- Updated scalar and vector conversion paths to use the software conversion helpers.

## C++ style / lint notes

- The PR changes C++ implementation code but does not change `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step may report advisory style warnings. These do not indicate correctness or build failures.
- No new public API declarations were added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->