### PR TITLE
[MetaxGPU][testing] Un-xfail gemm_sp tests; fix FP8 compare and compress sync.

### DIFF
--- a/examples/gemm_sp/sparse_utils.py
+++ b/examples/gemm_sp/sparse_utils.py
@@ -59,6 +59,7 @@ def _compress_fn(D, dtype, meta_dtype, block_M=_BLOCK_M, block_K=_BLOCK_K, elem_
                     dense[bz * block_M + tm, bk * block_K + tn * elem_per_thread : k_base + (tn + 1) * elem_per_thread],
                     dense_local,
                 )
+                T.sync_threads()
 
                 for gid in T.unroll(elem_per_thread // group):
                     T.clear(nz_idx)
@@ -131,6 +132,7 @@ def _compress_fn(D, dtype, meta_dtype, block_M=_BLOCK_M, block_K=_BLOCK_K, elem_
                     dense[bz * block_M + tm, k_base + tn * elem_per_thread : k_base + (tn + 1) * elem_per_thread],
                     dense_local,
                 )
+                T.sync_threads()
 
                 for gid in T.unroll(elem_per_thread // group):
                     T.clear(nz_idx)

--- a/examples/gemm_sp/test_example_gemm_sp.py
+++ b/examples/gemm_sp/test_example_gemm_sp.py
@@ -3,7 +3,6 @@ import tilelang.testing
 import example_gemm_sp
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_example_gemm_sp():
     example_gemm_sp.main()

--- a/src/tl_templates/maca/maca_fp8.h
+++ b/src/tl_templates/maca/maca_fp8.h
@@ -146,6 +146,14 @@ public:
   }
 };
 
+TL_DEVICE bool operator==(fp8_e4_t lhs, fp8_e4_t rhs) {
+  return lhs.v.__x == rhs.v.__x;
+}
+
+TL_DEVICE bool operator!=(fp8_e4_t lhs, fp8_e4_t rhs) {
+  return lhs.v.__x != rhs.v.__x;
+}
+
 TL_DEVICE half_t __cvt_fp8_e5m2_to_half(__maca_fp8_e5m2 x) {
   uint16_t bits = (uint16_t)x.__x;
   bits = (uint16_t)(bits << 8U);
@@ -248,6 +256,14 @@ public:
     return static_cast<To>(v);
   }
 };
+
+TL_DEVICE bool operator==(fp8_e5_t lhs, fp8_e5_t rhs) {
+  return lhs.v.__x == rhs.v.__x;
+}
+
+TL_DEVICE bool operator!=(fp8_e5_t lhs, fp8_e5_t rhs) {
+  return lhs.v.__x != rhs.v.__x;
+}
 
 TL_DEVICE unsigned char __tl_cvt_float_to_e8m0(const float src);
 TL_DEVICE unsigned char __tl_cvt_double_to_e8m0(const double src);

--- a/testing/python/tilelibrary/test_tilelang_tilelibrary_gemm_sp.py
+++ b/testing/python/tilelibrary/test_tilelang_tilelibrary_gemm_sp.py
@@ -116,7 +116,12 @@ def run_gemm_ss(
             B = B.T
         A = A.to(torch.float32)
         B = B.to(torch.float32)
-        return torch.matmul(A, B)
+        if in_dtype == T.int8:
+            torch.backends.cuda.matmul.allow_tf32 = False
+        C = torch.matmul(A, B)
+        if in_dtype == T.int8:
+            torch.backends.cuda.matmul.allow_tf32 = True
+        return C
 
     C = _matmul(A, B)
 
@@ -149,7 +154,6 @@ def generate_dense_input(M, N, K, trans_A, trans_B, in_dtype, seed=0):
     return A, B
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
     "M, N, K, trans_A, trans_B, in_dtype, out_dtype, dtypeAccum, block_M, block_N, block_K, num_stages, num_threads, meta_dtype",
@@ -304,7 +308,12 @@ def run_gemm_rs(
             B = B.T
         A = A.to(torch.float32)
         B = B.to(torch.float32)
-        return torch.matmul(A, B)
+        if in_dtype == T.int8:
+            torch.backends.cuda.matmul.allow_tf32 = False
+        C = torch.matmul(A, B)
+        if in_dtype == T.int8:
+            torch.backends.cuda.matmul.allow_tf32 = True
+        return C
 
     C = _matmul(A, B)
 
@@ -318,7 +327,6 @@ def run_gemm_rs(
     )
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
     "M, N, K, trans_A, trans_B, in_dtype, out_dtype, dtypeAccum, block_M, block_N, block_K, num_stages, num_threads, meta_dtype",
@@ -474,7 +482,12 @@ def run_gemm_sr(
             B = B.T
         A = A.to(torch.float32)
         B = B.to(torch.float32)
-        return torch.matmul(A, B)
+        if in_dtype == T.int8:
+            torch.backends.cuda.matmul.allow_tf32 = False
+        C = torch.matmul(A, B)
+        if in_dtype == T.int8:
+            torch.backends.cuda.matmul.allow_tf32 = True
+        return C
 
     C = _matmul(A, B)
 
@@ -488,7 +501,6 @@ def run_gemm_sr(
     )
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
     "M, N, K, trans_A, trans_B, in_dtype, out_dtype, dtypeAccum, block_M, block_N, block_K, num_stages, num_threads, meta_dtype",
@@ -648,7 +660,12 @@ def run_gemm_rr(
             B = B.T
         A = A.to(torch.float32)
         B = B.to(torch.float32)
-        return torch.matmul(A, B)
+        if in_dtype == T.int8:
+            torch.backends.cuda.matmul.allow_tf32 = False
+        C = torch.matmul(A, B)
+        if in_dtype == T.int8:
+            torch.backends.cuda.matmul.allow_tf32 = True
+        return C
 
     C = _matmul(A, B)
 
@@ -662,7 +679,6 @@ def run_gemm_rr(
     )
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
     "M, N, K, trans_A, trans_B, in_dtype, out_dtype, dtypeAccum, block_M, block_N, block_K, num_stages, num_threads, meta_dtype",
@@ -701,7 +717,6 @@ def test_gemm_rr(
     )
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
     "in_dtype, out_dtype, dtypeAccum, meta_dtype",

--- a/testing/python/utils/test_compress_utils.py
+++ b/testing/python/utils/test_compress_utils.py
@@ -123,7 +123,6 @@ def _test_compress(dtype, meta_dtype):
     torch_assert_close(C_tl, C_ref, atol=1e-2, rtol=1e-2)
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
     "dtype, meta_dtype",

--- a/tilelang/maca/intrinsics/macro/mma_sp_macro_generator.py
+++ b/tilelang/maca/intrinsics/macro/mma_sp_macro_generator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import tilelang.language as T
+from tilelang.backend.target import determine_target
 from typing import Literal
 from collections.abc import Callable
 from tvm import DataType, tirx
@@ -9,15 +10,7 @@ from tvm.ir import Range
 from tvm.runtime import convert
 from ..layout.utils import mma_store_index_map
 from tilelang.utils import is_fragment, get_buffer_region_from_load
-
-from tilelang.maca.intrinsics.layout.mma_sp_layout import (
-    shared_16x16_to_mma_sp_layout_sr_a,
-    shared_16x16_to_mma_sp_layout_sr_b,
-    shared_16x32_to_mma_sp_layout_sr_a,
-    shared_16x32_to_mma_sp_layout_sr_b,
-    shared_16x64_to_mma_sp_layout_sr_a,
-    shared_16x64_to_mma_sp_layout_sr_b,
-)
+from tilelang.maca.intrinsics.layout.mma_layout import *
 
 
 lift = convert
@@ -46,27 +39,6 @@ class SparseTensorCoreIntrinEmitter:
         "float8_e5m2": "e5m2",
     }
 
-    E_FACTOR_MAP = {  # e_kdim = mma_kdim // e_factor
-        "float": {"int16": 8, "uint16": 8},
-        "float32": {"int16": 8, "uint16": 8},
-        "float16": {"int8": 8, "uint8": 8, "int16": 16, "uint16": 16, "int32": 32, "uint32": 32},
-        "bfloat16": {"int8": 8, "uint8": 8, "int16": 16, "uint16": 16, "int32": 32, "uint32": 32},
-        "int8": {"int8": 8, "uint8": 8, "int16": 16, "uint16": 16, "int32": 32, "uint32": 32},
-        "uint8": {"int8": 8, "uint8": 8, "int16": 16, "uint16": 16, "int32": 32, "uint32": 32},
-        "float8_e4m3": {"int8": 8, "uint8": 8, "int16": 16, "uint16": 16, "int32": 32, "uint32": 32},
-        "float8_e5m2": {"int8": 8, "uint8": 8, "int16": 16, "uint16": 16, "int32": 32, "uint32": 32},
-    }
-
-    E_REPLICATE_FACTOR = {  # metadata replicate every 4 consecutive threads
-        "float32": 2,
-        "float16": 2,  # 2 of 4 consecutive threads provides
-        "bfloat16": 2,
-        "int8": 1,  # 4 of 4 consecutive threads provides
-        "uint8": 1,
-        "float8_e4m3": 1,
-        "float8_e5m2": 1,
-    }
-
     # Represent the thread binding in the form of (tx, warp_n, warp_m)
     is_m_first = False
 
@@ -88,11 +60,12 @@ class SparseTensorCoreIntrinEmitter:
         num_elems_per_byte: int = 1,
         is_m_first: bool = False,
         thread_var: Var | None = None,
+        blockn8_flag: bool = False,
     ):
-        self.a_dtype = a_dtype
-        self.e_dtype = e_dtype
-        self.b_dtype = b_dtype
-        self.accum_dtype = accum_dtype
+        self.a_dtype = str(a_dtype)
+        self.e_dtype = str(e_dtype)
+        self.b_dtype = str(b_dtype)
+        self.accum_dtype = str(accum_dtype)
         self.a_transposed = a_transposed
         self.b_transposed = b_transposed
         self.e_transposed = e_transposed
@@ -102,14 +75,13 @@ class SparseTensorCoreIntrinEmitter:
         self.warp_row_tiles = warp_row_tiles
         self.warp_col_tiles = warp_col_tiles
         self.warp_k = warp_k
-        self.e_factor = self.E_FACTOR_MAP[self.a_dtype][self.e_dtype]
-        self._initialize_k_dim(a_dtype)
-        self._initialize_abbrev(a_dtype, b_dtype, accum_dtype)
+        self._initialize_k_dim(self.a_dtype)
+        self._initialize_abbrev(self.a_dtype, self.b_dtype, self.accum_dtype)
         self._initialize_micro_size(self.M_DIM, self.k_dim)
         self._initialize_local_size(self.M_DIM, self.N_DIM, self.k_dim, self.WARP_SIZE)
         self._initialize_mma_prefix(self.k_dim)
         self._initialize_is_m_first(is_m_first)
-
+        self.blockn8_flag = blockn8_flag
         self.reduce_k = reduce_k
         self.threads = self.WARP_SIZE * (block_row_warps * block_col_warps) * reduce_k
         self.num_elems_per_byte = num_elems_per_byte
@@ -120,23 +92,42 @@ class SparseTensorCoreIntrinEmitter:
                 f"Invalid threads configuration for this tile shape, {self.warp_rows} x {self.warp_cols} with threads {self.threads}"
             )
 
+    def get_target_serial(self):
+        target = determine_target(return_object=True)
+        xcore = target.attrs.get("mcpu")
+        non_digits_part = xcore.rstrip("0123456789")
+        xcore_num = int(xcore[len(non_digits_part) :])
+        return xcore_num
+
     def _initialize_k_dim(self, a_dtype="float16"):
+        serial = self.get_target_serial()
         if isinstance(a_dtype, str):
             if a_dtype in ["float8_e4m3fn", "float8_e4m3fnuz", "float8_e5m2", "float8_e5m2fnuz"]:
                 self.k_dim = 32
                 return
             a_dtype = DataType(a_dtype)
 
-        if a_dtype.bits == 64 or a_dtype.bits == 32:
+        if a_dtype.bits == 32:
+            if a_dtype in {T.tfloat32, T.float32}:
+                self.k_dim = 8
+            else:
+                self.k_dim = 4
+        elif a_dtype.bits == 64:
             self.k_dim = 4
-        elif a_dtype.bits in {16, 8}:
+        elif a_dtype.bits == 16:
             self.k_dim = 16
+        elif a_dtype.bits == 8:
+            if serial >= 1500 and serial <= 1600:
+                self.k_dim = 32
+            elif serial >= 1000 and serial < 1500:
+                self.k_dim = 16
+            else:
+                raise ValueError("Unsupported MetaXGPU Card")
         else:
             raise ValueError(f"Unsupported a_dtype = {a_dtype}")
 
     def _initialize_local_size(self, m_dim=16, n_dim=16, k_dim=16, warp_size=64):
         self.local_size_a = (m_dim * k_dim) // warp_size
-        self.local_size_e = (m_dim * k_dim) // self.e_factor // warp_size * self.E_REPLICATE_FACTOR[self.a_dtype]
         self.local_size_b = (n_dim * k_dim) // warp_size
         self.local_size_out = (m_dim * n_dim) // warp_size
 
@@ -145,18 +136,19 @@ class SparseTensorCoreIntrinEmitter:
         self.b_dtype_abbrv = self.dtype_abbrv[b_dtype]
         self.accum_dtype_abbrv = self.dtype_abbrv[accum_dtype]
 
-    def _initialize_mma_prefix(self, k_dim: int = 16):
+    def _initialize_mma_prefix(self, k_dim=16):
         in_dtype = self.a_dtype
         M_DIM, N_DIM = self.M_DIM, self.N_DIM
+
         in_dtype_abbrv = {
             "bfloat16": "bf16",
             "float16": "f16",
-            "float32": "f32",
+            "float32": "tf32",
             "float64": "f64",
             "int8": "i8",
             "int32": "i32",
-            "float8_e4m3fn": "fp8",
-            "float8_e4m3fnuz": "fp8",
+            "float8_e4m3fn": "f8",
+            "float8_e4m3fnuz": "f8",
             "float8_e5m2": "bf8",
             "float8_e5m2fnuz": "bf8",
         }[in_dtype]
@@ -253,7 +245,6 @@ class SparseTensorCoreIntrinEmitter:
         local_size_a = self.local_size_a
         a_transposed = self.a_transposed
         e_transposed = self.e_transposed
-        e_factor = self.e_factor
         thread_binding = self.get_thread_binding()
 
         A_region = self._legalize_to_buffer_region(A_shared_buf)
@@ -296,18 +287,21 @@ class SparseTensorCoreIntrinEmitter:
                             if a_transposed
                             else A_buf[tuple(A_other) + (A_base0 + l + row, A_base1 + r + col + groupoffset // 2)]
                         )
-
                         rowe, cole = getindexe(tx, k)
-                        le, re = (warp_m * warp_row_tiles + i * micro_size_x, ki * micro_size_k // e_factor)
-                        offsetk = ki * micro_size_k % e_factor
+                        le = (warp_m * warp_row_tiles + i * micro_size_x, 0)[0]
+
+                        dtype_bits = DataType(self.e_dtype).bits
+                        total_bits = (ki * micro_size_k + cole + groupoffset) + k * 2
+                        E_re = total_bits // dtype_bits
+                        E_shift = total_bits % dtype_bits
                         if e_transposed:
-                            E_elementi = (
-                                E_buf[tuple(E_other) + (E_base0 + re, E_base1 + rowe + le)] >> (cole + groupoffset + offsetk + k * 2)
-                            ) & 0b11
+                            E_val = E_buf[tuple(E_other) + (E_base0 + E_re, E_base1 + rowe + le)]
                         else:
-                            E_elementi = (
-                                E_buf[tuple(E_other) + (E_base0 + rowe + le, E_base1 + re)] >> (cole + groupoffset + offsetk + k * 2)
-                            ) & 0b11
+                            E_val = E_buf[tuple(E_other) + (E_base0 + rowe + le, E_base1 + E_re)]
+                        if self.SPARSE_FACTOR == 2:
+                            E_elementi = (E_val >> E_shift) & 0b11
+                        else:
+                            E_elementi = ((E_val >> E_shift) >> 1) & 0b1
                         A_local_buf[i * local_size_a + groupoffset + E_elementi] = Ak
 
         return _warp_ldmatrix_a(A_local_buf, A_region, E_region, ki, thread_binding, rk)
@@ -390,7 +384,6 @@ class SparseTensorCoreIntrinEmitter:
         compute_a_dtype = a_dtype if local_size_a == 1 else f"{a_dtype}x{local_size_a}"
         compute_b_dtype = b_dtype if local_size_b == 1 else f"{b_dtype}x{local_size_b}"
         compute_out_dtype = out_dtype if local_size_out == 1 else f"{out_dtype}x{local_size_out}"
-
         a_is_fragment = is_fragment(A_local_buf)
         b_is_fragment = is_fragment(B_local_buf)
         a_local_stride: PrimExpr = k_inner * warp_rows * k_pack * local_size_a if a_is_fragment else 0
@@ -501,8 +494,6 @@ class SparseTensorCoreIntrinEmitter:
         assert matrix in ["A", "B"], "matrix should be either A or B"
         matrix_is_a: bool = matrix == "A"
         matrix_is_b: bool = matrix == "B"
-        dtype = self.a_dtype if matrix_is_a else self.b_dtype
-        dtype_bits = DataType(dtype).bits
         transposed = self.a_transposed if matrix_is_a else self.b_transposed
 
         # s represents spatial axis
@@ -513,17 +504,25 @@ class SparseTensorCoreIntrinEmitter:
         # then rs also can represent a transposed basic layout
         transform_func_sr_a: Callable = None
         transform_func_sr_b: Callable = None
-        if dtype_bits == 32:
-            transform_func_sr_a = shared_16x16_to_mma_sp_layout_sr_a
-            transform_func_sr_b = shared_16x16_to_mma_sp_layout_sr_b
-        elif dtype_bits == 16:
-            transform_func_sr_a = shared_16x32_to_mma_sp_layout_sr_a
-            transform_func_sr_b = shared_16x32_to_mma_sp_layout_sr_b
-        elif dtype_bits == 8:
-            transform_func_sr_a = shared_16x64_to_mma_sp_layout_sr_a
-            transform_func_sr_b = shared_16x64_to_mma_sp_layout_sr_b
+        k_dim = self.k_dim
+
+        if k_dim == 4:
+            transform_func_sr_a = shared_16x4_to_local_64x1_layout_A
+            transform_func_sr_b = shared_16x4_to_local_64x1_layout_A
+        elif k_dim == 8:
+            transform_func_sr_a = shared_16x4_to_local_64x1_layout_A
+            transform_func_sr_b = shared_16x8_to_local_64x2_layout_A
+        elif k_dim == 16:
+            transform_func_sr_a = shared_16x8_to_local_64x2_layout_A
+            transform_func_sr_b = shared_16x16_to_local_64x4_layout_A
+        elif k_dim == 32:
+            transform_func_sr_a = shared_16x16_to_local_64x4_layout_A
+            transform_func_sr_b = shared_16x32_to_local_64x8_layout_A
+        elif k_dim == 64:
+            transform_func_sr_a = shared_16x32_to_local_64x8_layout_A
+            transform_func_sr_b = shared_16x64_to_local_64x16_layout_A
         else:
-            raise ValueError(f"Unsupported dtype {dtype}")
+            raise ValueError(f"k_dim must be 4, 8, 16, 32, or 64 but got {k_dim}")
 
         is_sr_conditions = [False]
         is_sr_conditions.append(matrix_is_a and not transposed)
@@ -636,6 +635,7 @@ class SparseTensorCoreIntrinEmitter:
         warp_rows, warp_cols = self.warp_rows, self.warp_cols
         warp_size = self.WARP_SIZE
         is_m_first = self.is_m_first
+        blockn8_flag = self.blockn8_flag
 
         def forward_thread(i: int, j: int) -> int:
             """
@@ -654,6 +654,9 @@ class SparseTensorCoreIntrinEmitter:
                 thread_id = block_j * (block_row_warps * warp_size) + block_i * warp_size + lane_id
             return thread_id
 
+        def forward_thread_blockn8(i: int, j: int, rep: int):
+            return forward_thread(i, j) + rep * 32
+
         def forward_index(i: int, j: int) -> int:
             """
             Given the row index `i` and column index `j` in the fragment,
@@ -668,8 +671,12 @@ class SparseTensorCoreIntrinEmitter:
             _, local_id = inverse_mma_store_layout.map_indices([mma_i, mma_j])
             return warp_i * (warp_cols * local_size_out) + warp_j * local_size_out + local_id
 
-        return T.Fragment(
-            shape,
-            forward_thread_fn=forward_thread,
-            forward_index_fn=forward_index,
-        )
+        if not blockn8_flag:
+            resFragment = T.Fragment(
+                shape,
+                forward_thread_fn=forward_thread,
+                forward_index_fn=forward_index,
+            )
+        else:
+            resFragment = T.Fragment(shape, forward_thread_fn=forward_thread_blockn8, forward_index_fn=forward_index, replicate=2)
+        return resFragment

--- a/tilelang/maca/op/gemm_sp/gemm_sp_mma.py
+++ b/tilelang/maca/op/gemm_sp/gemm_sp_mma.py
@@ -15,13 +15,15 @@ GEMM_SP_INST_MMA_SP = "maca.mma.sp"
 class GemmSPMMA(GemmSPBase):
     def infer_layout(self, target: Target, thread_nums: int):
         # NOTE(wt): Actually gemm_sp v2 currently use GemmWarpPolicy
-        m_warp, n_warp = self.policy.compute_warp_partition(self.M, self.N, thread_nums, target, GEMM_SP_INST_MMA_SP)
+        blockn8_flag = self.N == 8
+        shapeN = self.N if not blockn8_flag else 16
+        m_warp, n_warp = self.policy.compute_warp_partition(self.M, shapeN, thread_nums, target, GEMM_SP_INST_MMA_SP)
         warp_row_tiles = int(self.M // m_warp)
-        warp_col_tiles = int(self.N // n_warp)
+        warp_col_tiles = int(shapeN // n_warp)
         mma_emitter = SparseTensorCoreIntrinEmitter(
-            a_dtype=self.in_dtype,
+            a_dtype=self.a_dtype,
             e_dtype=self.e_dtype,
-            b_dtype=self.in_dtype,
+            b_dtype=self.b_dtype,
             accum_dtype=self.accum_dtype,
             a_transposed=self.trans_A,
             b_transposed=self.trans_B,
@@ -31,6 +33,7 @@ class GemmSPMMA(GemmSPBase):
             warp_row_tiles=warp_row_tiles,
             warp_col_tiles=warp_col_tiles,
             warp_k=self.K,
+            blockn8_flag=blockn8_flag,
         )
         if self.is_gemm_ss():
             return {
@@ -59,14 +62,16 @@ class GemmSPMMA(GemmSPBase):
         else:
             raise ValueError(f"Unsupported gemm combination, A: {self.A.scope()}, B: {self.B.scope()}")
 
-    def lower(self, layout_map: dict, target: Target, thread_nums: int, thread_var: tirx.Var):
+    def lower(self, layout_map: dict, target: Target, thread_bounds: range, thread_var: tirx.Var):
         # NOTE(wt): Actually gemm_sp v2 currently use GemmWarpPolicy
-        m_warp, n_warp = self.policy.compute_warp_partition(self.M, self.N, thread_nums, target, GEMM_SP_INST_MMA_SP)
+        thread_nums = thread_bounds.extent
+        shapeN = self.N if self.N != 8 else 16
+        m_warp, n_warp = self.policy.compute_warp_partition(self.M, shapeN, thread_nums, target, GEMM_SP_INST_MMA_SP)
         warp_row_tiles = int(self.M // m_warp)
-        warp_col_tiles = int(self.N // n_warp)
+        warp_col_tiles = int(shapeN // n_warp)
         mma_emitter = SparseTensorCoreIntrinEmitter(
-            a_dtype=self.in_dtype,
-            b_dtype=self.in_dtype,
+            a_dtype=self.a_dtype,
+            b_dtype=self.b_dtype,
             e_dtype=self.e_dtype,
             accum_dtype=self.accum_dtype,
             a_transposed=self.trans_A,
@@ -80,11 +85,10 @@ class GemmSPMMA(GemmSPBase):
             thread_var=thread_var,
         )
 
-        in_dtype = self.in_dtype
+        in_dtype = self.a_dtype
         warp_rows = mma_emitter.warp_rows
         warp_cols = mma_emitter.warp_cols
         local_size_a = mma_emitter.local_size_a
-        local_size_e = mma_emitter.local_size_e
         local_size_b = mma_emitter.local_size_b
         micro_size_k = mma_emitter.micro_size_k
         A_shared = self.ARegion
@@ -141,7 +145,6 @@ class GemmSPMMA(GemmSPBase):
                 accumulating into C_local.
                 """
                 A_local = T.alloc_local((warp_rows * local_size_a), in_dtype)
-                E_local = T.alloc_local((warp_rows * local_size_e), self.e_dtype)
 
                 if clear_accum:
                     T.clear(C_local)
@@ -151,18 +154,12 @@ class GemmSPMMA(GemmSPBase):
                     mma_emitter.ldmatrix_a(
                         A_local,
                         A_shared,
-                        ki,
-                    )
-
-                    # Load E into fragment
-                    mma_emitter.ldmatrix_e(
-                        E_local,
                         E_shared,
                         ki,
                     )
 
                     # Perform Matrix Multiplication
-                    mma_emitter.mma_sp(A_local, E_local, B_local, C_local, ki)
+                    mma_emitter.mma(A_local, B_local, C_local, ki)
 
             # Simplify to optimize the index computing
             # Must inline let statements to simplify the analysis
@@ -170,7 +167,7 @@ class GemmSPMMA(GemmSPBase):
             # insert into parent block
             return _Simplify(_gemm_srr, inline_let=True)
         elif self.is_gemm_rs():
-            A_local = self.A
+            A_original = self.A
 
             @T.prim_func
             def _gemm_rsr() -> None:
@@ -179,7 +176,7 @@ class GemmSPMMA(GemmSPBase):
                 B_shared into local fragments, then issues Tensor Core mma ops,
                 accumulating into C_local.
                 """
-                E_local = T.alloc_local((warp_rows * local_size_e), self.e_dtype)
+                A_local = T.alloc_local((warp_rows * local_size_a), in_dtype)
                 B_local = T.alloc_local((warp_cols * local_size_b), in_dtype)
 
                 if clear_accum:
@@ -187,8 +184,9 @@ class GemmSPMMA(GemmSPBase):
 
                 for ki in T.serial(0, (self.K // micro_size_k)):
                     # Load E into fragment
-                    mma_emitter.ldmatrix_e(
-                        E_local,
+                    mma_emitter.ldmatrix_a(
+                        A_local,
+                        A_original,
                         E_shared,
                         ki,
                     )
@@ -201,13 +199,13 @@ class GemmSPMMA(GemmSPBase):
                     )
 
                     # Perform Matrix Multiplication
-                    mma_emitter.mma_sp(A_local, E_local, B_local, C_local, ki)
+                    mma_emitter.mma(A_local, B_local, C_local, ki)
 
             # Simplify to optimize the index computing
             # Must inline let statements to simplify the analysis
             return _Simplify(_gemm_rsr, inline_let=True)
         elif self.is_gemm_rr():
-            A_local = self.A
+            A_original = self.A
             B_local = self.B
 
             @T.prim_func
@@ -217,21 +215,22 @@ class GemmSPMMA(GemmSPBase):
                 B_shared into local fragments, then issues Tensor Core mma ops,
                 accumulating into C_local.
                 """
-                E_local = T.alloc_local((warp_rows * local_size_e), self.e_dtype)
+                A_local = T.alloc_local((warp_rows * local_size_a), in_dtype)
 
                 if clear_accum:
                     T.clear(C_local)
 
                 for ki in T.serial(0, (self.K // micro_size_k)):
                     # Load E into fragment
-                    mma_emitter.ldmatrix_e(
-                        E_local,
+                    mma_emitter.ldmatrix_a(
+                        A_local,
+                        A_original,
                         E_shared,
                         ki,
                     )
 
                     # Perform Matrix Multiplication
-                    mma_emitter.mma_sp(A_local, E_local, B_local, C_local, ki)
+                    mma_emitter.mma(A_local, B_local, C_local, ki)
 
             # Simplify to optimize the index computing
             # Must inline let statements to simplify the analysis


### PR DESCRIPTION
## Summary
- Add `operator==` / `operator!=` for MACA `fp8_e4_t` and `fp8_e5_t` so sparse compress can compare FP8 values to zero.
- Insert `T.sync_threads()` after loading into `dense_local` in `examples/gemm_sp/sparse_utils.py` compress.
- Re-enable `gemm_sp` example/tilelibrary tests; 
- Switch tilelibrary tests to `tilelang.utils.sparse` and disable TF32 for int8 reference matmul.
- Support N==8 on MACA gemm_sp MMA path 

## Notes
- Cherry-picked / adapted the MACA gemm_sp SR/RS/RR path from
  https://github.com/tile-ai/tilelang-metax/pull/105
  (`gemm_sp_mma.py` + `mma_sp_macro_generator.py`), which is not yet merged.
- Reason: current tree still uses `self.in_dtype` and SR/RS/RR still call
  missing `ldmatrix_e` / `mma_sp`; #105 integrates `E` into `ldmatrix_a` and
  uses `mma()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Enabled sparse GEMM and tilelibrary tests for MetaxGPU.
- Added `==` and `!=` operators for MACA `fp8_e4_t` and `fp8_e5_t`.
- Added thread synchronization before sparse compression processing.
- Updated sparse MMA lowering and emission for `N == 8`, architecture-specific layouts, metadata extraction, and data types.
- Switched tilelibrary tests to `tilelang.utils.sparse`.
- Disabled TF32 during `int8` reference matrix multiplication.

## C++ style / lint notes

- The PR changes the MACA C++ FP8 header.
- It does not change rules documented in `docs/developer_guide/cpp_style.md`.
- The `C++ API Style Audit (warning only)` remains advisory.
- No correctness or build issue is indicated by the added operators. Any style warnings should not block the PR unless they identify a new API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->