### PR TITLE
[MetaxGPU][JIT] Add MCRTC runtime compilation backend

### DIFF
--- a/src/maca/codegen/codegen_maca.cc
+++ b/src/maca/codegen/codegen_maca.cc
@@ -408,7 +408,6 @@ std::string CodeGenTileLangMACA::Finish() {
     decl_stream << "#include <mcrand/mcrand_kernel.h>\n";
   }
 
-  decl_stream << "#include <tl_templates/maca/gemm.h>\n";
   if (enable_sparse_gemm_) {
     decl_stream << "#include <tl_templates/maca/gemm_sp.h>\n";
   }

--- a/src/tl_templates/maca/atomic.h
+++ b/src/tl_templates/maca/atomic.h
@@ -4,7 +4,6 @@
 #include <atomic>
 #include <common/maca_bfloat16.h>
 #include <common/maca_fp16.h>
-#include <mctlass/numeric_types.h>
 #include <type_traits>
 
 using half_t = __half;

--- a/src/tl_templates/maca/common.h
+++ b/src/tl_templates/maca/common.h
@@ -6,10 +6,9 @@
 #include "atomic.h"
 #include <common/maca_bfloat16.h>
 #include <common/maca_fp16.h>
-#include <cute/arch/mma.hpp>
-#include <cute/underscore.hpp>
+#include <cstdio>
+#include <limits>
 #include <mcr/mc_runtime.h>
-#include <mctlass/fast_math.h>
 
 #define MACART_INF_F __int_as_float(0x7f800000)
 #define MACART_NEGINF_F __int_as_float(0xff800000)
@@ -98,6 +97,7 @@ using int8x4 = __attribute__((__vector_size__(4 * sizeof(int8_t)))) int8_t;
 
 namespace platform {
 
+template <typename T> struct numeric_limits : std::numeric_limits<T> {};
 /// Numeric limits
 template <> struct numeric_limits<__half> {
   static bool const is_specialized = true;

--- a/src/tl_templates/maca/intrin.h
+++ b/src/tl_templates/maca/intrin.h
@@ -1,10 +1,7 @@
 #pragma once
 
 #include "common.h"
-#include "mctlass/mctlass.h"
-
-#include "cute/arch/cluster_sm90.hpp"
-#include "cute/arch/mma_sm90_gmma.hpp"
+#include <assert.h>
 
 namespace tl {
 
@@ -21,6 +18,14 @@ TL_DEVICE int linear_thread_idx_in_block() {
   return threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
 #else
   return 0;
+#endif
+}
+
+TL_DEVICE bool elect_one_sync() {
+#if defined(__MACA_ARCH__)
+  return (threadIdx.x % NumThreadsPerWarp) == 0;
+#else
+  return false;
 #endif
 }
 
@@ -52,31 +57,30 @@ get_warp_group_idx(int warp_size = detail::default_warp_size(),
   return detail::linear_thread_idx_in_block() / threads_per_group;
 }
 
-TL_DEVICE void warpgroup_arrive() { cute::warpgroup_arrive(); }
-TL_DEVICE void warpgroup_commit_batch() { cute::warpgroup_commit_batch(); }
+TL_DEVICE void warpgroup_arrive() {
+  assert(false && "warpgroup_arrive is not supported on MACA");
+}
+
+TL_DEVICE void warpgroup_commit_batch() {
+  assert(false && "warpgroup_commit_batch is not supported on MACA");
+}
 
 template <int NumMma> TL_DEVICE void warpgroup_wait() {
-  cute::warpgroup_wait<NumMma>();
+  assert(false && "warpgroup_wait is not supported on MACA");
 }
 
 TL_DEVICE void warpgroup_fence_operand(uint32_t *regs, int count) {
-#pragma unroll
-  for (int i = 0; i < count; ++i) {
-    cute::warpgroup_fence_operand(regs[i]);
-  }
+  assert(false && "warpgroup_fence_operand is not supported on MACA");
 }
 
 TL_DEVICE void warpgroup_fence_operand(float *regs, int count) {
-#pragma unroll
-  for (int i = 0; i < count; ++i) {
-    cute::warpgroup_fence_operand(regs[i]);
-  }
+  assert(false && "warpgroup_fence_operand is not supported on MACA");
 }
 
-MCTLASS_DEVICE
+TL_DEVICE
 int canonical_warp_idx_sync() {
 #if defined(__MACA_ARCH__)
-  return __shfl_sync(UINT64_MAX, threadIdx.x / NumThreadsPerWarp, 0);
+  return __shfl_sync(0xffffffff, threadIdx.x / NumThreadsPerWarp, 0);
 #else
   return 0;
 #endif
@@ -101,9 +105,9 @@ template <int thread_extent> TL_DEVICE bool tl_shuffle_elect() {
     // The condition ensures that:
     //   (1) We are in warp 0 of the block.
     //   (2) We are the elected lane in this warp.
-    return canonical_warp_idx_sync() == 0 && cute::elect_one_sync();
+    return canonical_warp_idx_sync() == 0 && detail::elect_one_sync();
   } else if constexpr (thread_extent == 64) {
-    return cute::elect_one_sync();
+    return detail::elect_one_sync();
   }
   // General case: thread_extent != 0
   // (threadIdx.x / 64) is the warp index in the block.
@@ -114,13 +118,20 @@ template <int thread_extent> TL_DEVICE bool tl_shuffle_elect() {
   // lanes in the warp. Here it broadcasts the group-local warp index from lane
   // 0. Comparing to 0 selects only the group's warp 0.
   return __shfl_sync(UINT64_MAX, // full warp mask
-                     (threadIdx.x / 64) %
+                     (threadIdx.x / 64) /
                          (thread_extent / 64), // warp index within group
                      0                         // take the value from lane 0
                      ) == 0 &&
          // Within that group leader warp, elect exactly one lane (typically
          // lane 0) to be the single representative for the group.
-         cute::elect_one_sync();
+         detail::elect_one_sync();
 }
 
+template <uint32_t RegCount> TL_DEVICE void warpgroup_reg_alloc() {
+  assert(false && "warpgroup_reg_alloc is not supported on MACA");
+}
+
+template <uint32_t RegCount> TL_DEVICE void warpgroup_reg_dealloc() {
+  assert(false && "warpgroup_reg_dealloc is not supported on MACA");
+}
 } // namespace tl

--- a/src/tl_templates/maca/scan.h
+++ b/src/tl_templates/maca/scan.h
@@ -17,7 +17,7 @@ struct ScanSumOp {
 
 struct ScanMaxOp {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) {
-    return mctlass::fast_max(x, y);
+    return max(x, y);
   }
 
   template <typename T> TL_DEVICE static T identity() {

--- a/testing/python/jit/test_tilelang_jit_nvrtc.py
+++ b/testing/python/jit/test_tilelang_jit_nvrtc.py
@@ -129,7 +129,7 @@ def run_gemm_jit_kernel(
         num_threads,
     )
 
-    matmul_kernel = tilelang.compile(program, out_idx=-1, execution_backend="nvrtc")
+    matmul_kernel = tilelang.compile(program, out_idx=-1, execution_backend="mcrtc")
 
     in_dtype = T.dtype(in_dtype).as_torch()
     out_dtype = T.dtype(out_dtype).as_torch()
@@ -165,7 +165,7 @@ def test_gemm_jit_kernel():
         False,
         T.float16,
         T.float16,
-        T.float16,
+        T.float32,
         128,
         256,
         32,
@@ -192,7 +192,7 @@ def run_nvrtc_kernel_do_bench(
         num_threads,
     )
 
-    matmul_kernel = tilelang.compile(program, execution_backend="nvrtc")
+    matmul_kernel = tilelang.compile(program, execution_backend="mcrtc")
 
     profiler = matmul_kernel.get_profiler()
 
@@ -232,7 +232,7 @@ def run_nvrtc_kernel_multi_stream(
         num_threads,
     )
 
-    matmul_kernel = tilelang.compile(program, execution_backend="nvrtc")
+    matmul_kernel = tilelang.compile(program, execution_backend="mcrtc")
     in_dtype = T.dtype(in_dtype).as_torch()
     out_dtype = T.dtype(out_dtype).as_torch()
     tensor_a = torch.randn(M, K, dtype=in_dtype).cuda()
@@ -245,15 +245,20 @@ def run_nvrtc_kernel_multi_stream(
     tensor_c = torch.randn(M, N, dtype=out_dtype).cuda()
 
     num_streams = 4
+    streams = []
     for _ in range(num_streams):
         stream = torch.cuda.Stream()
+        streams.append(stream)
         with torch.cuda.stream(stream):
             matmul_kernel(tensor_a, tensor_b, tensor_c)
+
+    for stream in streams:
+        stream.synchronize()
 
 
 @tilelang.testing.requires_cuda
 def test_nvrtc_kernel_multi_stream():
-    run_nvrtc_kernel_multi_stream(512, 1024, 768, False, False, T.float16, T.float16, T.float16, 128, 256, 32, 2)
+    run_nvrtc_kernel_multi_stream(512, 1024, 768, False, False, T.float16, T.float16, T.float32, 128, 256, 32, 2)
 
 
 def run_nvrtc_dynamic_shape(
@@ -275,7 +280,7 @@ def run_nvrtc_dynamic_shape(
         num_threads,
     )
 
-    matmul_kernel = tilelang.compile(program, execution_backend="nvrtc")
+    matmul_kernel = tilelang.compile(program, execution_backend="mcrtc")
     if isinstance(M, T.Var):
         M = 1024
     if isinstance(N, T.Var):
@@ -303,11 +308,11 @@ def run_nvrtc_dynamic_shape(
 
 @tilelang.testing.requires_cuda
 def test_nvrtc_dynamic_shape():
-    run_nvrtc_dynamic_shape(T.dynamic("m"), 1024, 768, False, False, T.float16, T.float16, T.float16, 128, 256, 32, 2)
+    run_nvrtc_dynamic_shape(T.dynamic("m"), 1024, 768, False, False, T.float16, T.float16, T.float32, 128, 256, 32, 2)
 
-    run_nvrtc_dynamic_shape(T.dynamic("m"), T.dynamic("n"), 768, False, False, T.float16, T.float16, T.float16, 128, 256, 32, 2)
+    run_nvrtc_dynamic_shape(T.dynamic("m"), T.dynamic("n"), 768, False, False, T.float16, T.float16, T.float32, 128, 256, 32, 2)
 
-    run_nvrtc_dynamic_shape(T.dynamic("m"), T.dynamic("n"), T.dynamic("k"), False, False, T.float16, T.float16, T.float16, 128, 256, 32, 2)
+    run_nvrtc_dynamic_shape(T.dynamic("m"), T.dynamic("n"), T.dynamic("k"), False, False, T.float16, T.float16, T.float32, 128, 256, 32, 2)
 
 
 def check_hopper():
@@ -354,7 +359,7 @@ def run_nvrtc_im2col_tma_desc(N, C, H, W, F, K, S, D, P, block_M, block_N, block
     """Test im2col TMA descriptor functionality in NVRTC backend."""
     program = convolution_im2col(N, C, H, W, F, K, S, D, P, block_M, block_N, block_K, num_stages, num_threads)
 
-    conv_kernel = tilelang.compile(program, out_idx=-1, execution_backend="nvrtc")
+    conv_kernel = tilelang.compile(program, out_idx=-1, execution_backend="mcrtc")
 
     a = torch.randn(N, H, W, C).cuda().half()
     b = torch.randn(K, K, C, F).cuda().half()
@@ -395,7 +400,7 @@ def test_nvrtc_l2_persistent_map():
     M = 1024
     N = 1024
 
-    @tilelang.jit(out_idx=[-1], execution_backend="nvrtc")
+    @tilelang.jit(out_idx=[-1], execution_backend="mcrtc")
     def elementwise_add_with_l2_cache(
         M,
         N,
@@ -446,7 +451,7 @@ def test_nvrtc_pdl():
 
     N = 64
 
-    @tilelang.jit(execution_backend="nvrtc")
+    @tilelang.jit(execution_backend="mcrtc")
     def multi_kernels_with_pdl(N, block_size=256, dtype=T.float32):
         @T.prim_func
         def main(

--- a/tilelang/autotuner/param.py
+++ b/tilelang/autotuner/param.py
@@ -36,6 +36,7 @@ HOST_KERNEL_PATH = "host_kernel.cu"
 EXECUTABLE_PATH = "executable.so"
 KERNEL_LIB_PATH = "kernel_lib.so"
 KERNEL_CUBIN_PATH = "kernel.cubin"
+KERNEL_MCBIN_PATH = "kernel.mcbin"
 KERNEL_PY_PATH = "kernel.py"
 PARAMS_PATH = "params.pkl"
 TargetLike = str | dict[str, object] | Target
@@ -55,7 +56,7 @@ class CompileArgs:
     """
 
     out_idx: list[int] | int | None = None
-    execution_backend: Literal["auto", "tvm_ffi", "cython", "nvrtc", "torch"] = "auto"
+    execution_backend: Literal["auto", "tvm_ffi", "cython", "nvrtc", "mcrtc", "torch"] = "auto"
     target: TargetLike = "auto"
     target_host: TargetLike | None = None
     verbose: bool = False
@@ -246,6 +247,19 @@ class AutotuneResult:
             if verbose:
                 logger.debug(f"Saving kernel library to file: {kernel_lib_path}")
             self._safe_write_file(kernel_lib_path, "wb", lambda f: f.write(self._load_binary(src_lib_path)))
+        elif kernel.execution_backend == "mcrtc":
+            # Save mcbin and MCRTC Python helper file
+            src_lib_path = kernel.adapter.libpath
+            if not src_lib_path.endswith(".mcbin"):
+                raise ValueError(f"MCRTC kernel library must use the .mcbin suffix, got: {src_lib_path}")
+            kernel_py_path = os.path.join(cache_path, KERNEL_PY_PATH)
+            py_src_path = src_lib_path.replace(".mcbin", ".py")
+            if verbose:
+                logger.debug(f"Saving kernel mcrtc python code to file: {kernel_py_path}")
+            self._safe_write_file(kernel_py_path, "wb", lambda f: f.write(self._load_binary(py_src_path)))
+            if verbose:
+                logger.debug(f"Saving MCRTC kernel library to file: {kernel_lib_path}")
+            self._safe_write_file(kernel_lib_path, "wb", lambda f: f.write(self._load_binary(src_lib_path)))
         elif kernel.execution_backend == "tvm_ffi":
             if hasattr(kernel.adapter, "libpath") and kernel.adapter.libpath:
                 src_lib_path = kernel.adapter.libpath
@@ -300,7 +314,7 @@ class AutotuneResult:
         target: TargetLike = "auto",
         target_host: TargetLike | None = None,
         out_idx: list[int] | int | None = None,
-        execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"] = "tvm_ffi",
+        execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "mcrtc", "torch", "cutedsl"] = "tvm_ffi",
         pass_configs: dict = None,
         compile_flags: list[str] | str | None = None,
         func: Callable = None,
@@ -545,6 +559,8 @@ class AutotuneResult:
         """Return the cache filename for one backend's executable artifact."""
         if execution_backend == "nvrtc":
             return KERNEL_CUBIN_PATH
+        if execution_backend == "mcrtc":
+            return KERNEL_MCBIN_PATH
         if execution_backend == "tvm_ffi":
             return EXECUTABLE_PATH
         if execution_backend == "cutedsl":
@@ -555,7 +571,7 @@ class AutotuneResult:
     def _get_required_kernel_files(cls, path: Path, execution_backend: str) -> list[Path]:
         """Return backend-specific files required to reload a kernel."""
         files = [path / cls._get_kernel_lib_file(execution_backend)]
-        if execution_backend == "nvrtc":
+        if execution_backend == "nvrtc" or execution_backend == "mcrtc":
             files.append(path / KERNEL_PY_PATH)
         return files
 

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -291,7 +291,7 @@ class AutoTuner:
         self,
         out_idx: list[int] | int | None = None,
         target: TargetLike | None = None,
-        execution_backend: Literal["auto", "tvm_ffi", "cython", "nvrtc", "torch"] | None = None,
+        execution_backend: Literal["auto", "tvm_ffi", "cython", "nvrtc", "mcrtc", "torch"] | None = None,
         target_host: TargetLike | None = None,
         verbose: bool | None = None,
         pass_configs: dict[str, Any] | None = None,
@@ -1510,7 +1510,7 @@ def autotune(  # This is the new public interface
         Compilation target for TVM (e.g., "cuda", "llvm"). Defaults to "auto".
     target_host : Union[str, dict, Target], optional
         Target host for cross-compilation. Defaults to None.
-    execution_backend : Literal["auto", "tvm_ffi", "cython", "nvrtc", "torch"], optional
+    execution_backend : Literal["auto", "tvm_ffi", "cython", "nvrtc", "mcrtc", "torch"], optional
         Backend for kernel execution and argument passing. Use "auto" to pick a sensible
         default per target (cuda->tvm_ffi, metal->torch, others->cython).
     verbose : bool, optional

--- a/tilelang/cache/__init__.py
+++ b/tilelang/cache/__init__.py
@@ -11,6 +11,7 @@ from tilelang import env
 from tilelang.jit.adapter.cutedsl.kernel_cache import CuTeDSLKernelCache
 from tilelang.jit.adapter.cython.kernel_cache import CythonKernelCache
 from tilelang.jit.adapter.nvrtc.kernel_cache import NVRTCKernelCache
+from tilelang.jit.adapter.mcrtc.kernel_cache import MCRTCKernelCache
 from tilelang.jit.adapter.torch.kernel_cache import TorchKernelCache
 from tilelang.jit.adapter.kernel_cache import TVMFFIKernelCache
 
@@ -24,6 +25,7 @@ _dispatch_map: dict[str, KernelCache] = {
     "tvm_ffi": TVMFFIKernelCache(),
     "cython": CythonKernelCache(),
     "nvrtc": NVRTCKernelCache(),
+    "mcrtc": MCRTCKernelCache(),
     "cutedsl": CuTeDSLKernelCache(),
     "torch": TorchKernelCache(),
 }
@@ -31,7 +33,7 @@ _dispatch_map: dict[str, KernelCache] = {
 
 def _resolve_cache_dispatch(
     target: TargetLike | None,
-    execution_backend: Literal["auto", "tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"] | None,
+    execution_backend: Literal["auto", "tvm_ffi", "cython", "nvrtc", "mcrtc", "torch", "cutedsl"] | None,
     verbose: bool | None,
 ):
     if target is None:
@@ -70,7 +72,7 @@ def cached(
     *args,
     target: TargetLike | None = None,
     target_host: TargetLike | None = None,
-    execution_backend: Literal["auto", "tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"] | None = None,
+    execution_backend: Literal["auto", "tvm_ffi", "cython", "nvrtc", "mcrtc", "torch", "cutedsl"] | None = None,
     verbose: bool | None = None,
     pass_configs: dict | None = None,
     compile_flags: list[str] | str | None = None,

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -45,7 +45,7 @@ class KernelCache:
     _memory_cache = {}  # In-memory cache dictionary
     _staging_cleanup_lock = threading.Lock()
     _last_cleaned_staging_root: str | None = None
-    execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"] = "tvm_ffi"
+    execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "mcrtc", "torch", "cutedsl"] = "tvm_ffi"
     device_kernel_path = "device_kernel.cu"
     host_kernel_path = "host_kernel.cu"
     kernel_lib_path = "kernel_lib.so"
@@ -242,7 +242,7 @@ class KernelCache:
         self,
         func: Callable,
         out_idx: list[int],
-        execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"] = "tvm_ffi",
+        execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "mcrtc", "torch", "cutedsl"] = "tvm_ffi",
         args=None,
         target: str | Target = "auto",
         target_host: str | Target = None,
@@ -288,7 +288,7 @@ class KernelCache:
         *args,
         target: str | Target,
         target_host: str | Target | None = None,
-        execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"] = "tvm_ffi",
+        execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "mcrtc", "torch", "cutedsl"] = "tvm_ffi",
         verbose: bool,
         pass_configs: dict | None = None,
         compile_flags: list[str] | str | None = None,
@@ -552,7 +552,7 @@ class KernelCache:
         target: str | Target = "auto",
         target_host: str | Target | None = None,
         out_idx: list[int] | None = None,
-        execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"] = "tvm_ffi",
+        execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "mcrtc", "torch", "cutedsl"] = "tvm_ffi",
         pass_configs: dict | None = None,
         compile_flags: list[str] | str | None = None,
         func: Callable | None = None,
@@ -732,7 +732,7 @@ class KernelCache:
         target: str | Target,
         target_host: str | Target | None,
         out_idx: list[int] | None,
-        execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"],
+        execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "mcrtc", "torch", "cutedsl"],
         pass_configs: dict | None,
         compile_flags: list[str] | str | None,
     ) -> JITKernel | None:

--- a/tilelang/contrib/mcrtc.py
+++ b/tilelang/contrib/mcrtc.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+from pathlib import Path
+
+import ctypes
+import os
+
+
+MCRTC_SUCCESS = 0
+
+
+def _load_mcrtc_library() -> ctypes.CDLL:
+    maca_path = os.environ.get("MACA_PATH") or os.environ.get("MACA_HOME")
+    lib_path = os.path.join(maca_path, "lib", "libmcruntime.so") if maca_path else "libmcruntime.so"
+
+    try:
+        return ctypes.CDLL(lib_path)
+    except OSError as error:
+        raise ImportError(f"Failed to load MCRTC library: {lib_path}") from error
+
+
+mcrtc = _load_mcrtc_library()
+
+mcrtc.mcrtcGetErrorString.argtypes = [ctypes.c_int]
+mcrtc.mcrtcGetErrorString.restype = ctypes.c_char_p
+
+mcrtc.mcrtcVersion.argtypes = [ctypes.POINTER(ctypes.c_int), ctypes.POINTER(ctypes.c_int)]
+mcrtc.mcrtcVersion.restype = ctypes.c_int
+
+mcrtc.mcrtcCreateProgram.argtypes = [
+    ctypes.POINTER(ctypes.c_void_p),
+    ctypes.c_char_p,
+    ctypes.c_char_p,
+    ctypes.c_int,
+    ctypes.POINTER(ctypes.c_char_p),
+    ctypes.POINTER(ctypes.c_char_p),
+]
+mcrtc.mcrtcCreateProgram.restype = ctypes.c_int
+
+mcrtc.mcrtcCompileProgram.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.POINTER(ctypes.c_char_p)]
+mcrtc.mcrtcCompileProgram.restype = ctypes.c_int
+
+mcrtc.mcrtcGetProgramLogSize.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+mcrtc.mcrtcGetProgramLogSize.restype = ctypes.c_int
+
+mcrtc.mcrtcGetProgramLog.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+mcrtc.mcrtcGetProgramLog.restype = ctypes.c_int
+
+mcrtc.mcrtcGetBitcodeSize.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+mcrtc.mcrtcGetBitcodeSize.restype = ctypes.c_int
+
+mcrtc.mcrtcGetBitcode.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+mcrtc.mcrtcGetBitcode.restype = ctypes.c_int
+
+mcrtc.mcrtcDestroyProgram.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+mcrtc.mcrtcDestroyProgram.restype = ctypes.c_int
+
+
+def get_mcrtc_error_string(result: int) -> str:
+    message = mcrtc.mcrtcGetErrorString(result)
+    return message.decode("utf-8") if message else f"Unknown MCRTC error: {result}"
+
+
+def get_mcrtc_version() -> tuple[int, int]:
+    major = ctypes.c_int()
+    minor = ctypes.c_int()
+    result = mcrtc.mcrtcVersion(ctypes.byref(major), ctypes.byref(minor))
+    assert result == MCRTC_SUCCESS, f"Failed to get MCRTC version: {get_mcrtc_error_string(result)}"
+    return major.value, minor.value
+
+
+def compile_maca(
+    code: str,
+    options: str | list[str] | None = None,
+    verbose: bool = False,
+) -> bytes:
+    """Compile MACA code with MCRTC."""
+
+    file_name = "tvm_kernels"
+    tilelang_include = Path(__file__).resolve().parents[2] / "src"
+    maca_include = Path(os.environ.get("MACA_PATH", "/opt/maca")) / "include"
+    final_options = ["-std=c++17", f"-I{tilelang_include}", f"-I{maca_include}"]
+
+    if options:
+        if isinstance(options, str):
+            final_options.append(options)
+        elif isinstance(options, list):
+            final_options.extend(options)
+        else:
+            raise ValueError("options must be str or list of str")
+
+    code_bytes = bytes(code, "utf-8")
+    program = ctypes.c_void_p()
+
+    result = mcrtc.mcrtcCreateProgram(ctypes.byref(program), code_bytes, bytes(file_name, "utf-8"), 0, None, None)
+    assert result == MCRTC_SUCCESS, f"Failed to create program: {get_mcrtc_error_string(result)}"
+
+    try:
+        options_bytes = [bytes(option, "utf-8") for option in final_options]
+        options_array = (ctypes.c_char_p * len(options_bytes))(*options_bytes) if options_bytes else None
+        compile_result = mcrtc.mcrtcCompileProgram(program, len(options_bytes), options_array)
+
+        if compile_result != MCRTC_SUCCESS:
+            msg = f"{code}\nCompilation error:\n"
+            if verbose:
+                log_size = ctypes.c_size_t()
+                result = mcrtc.mcrtcGetProgramLogSize(program, ctypes.byref(log_size))
+                assert result == MCRTC_SUCCESS, f"Failed to get program log size: {get_mcrtc_error_string(result)}"
+                log_buffer = ctypes.create_string_buffer(log_size.value)
+                result = mcrtc.mcrtcGetProgramLog(program, log_buffer)
+                assert result == MCRTC_SUCCESS, f"Failed to get program log: {get_mcrtc_error_string(result)}"
+                msg += f"{log_buffer.value.decode('utf-8')}\n"
+            else:
+                msg += "Turn on verbose to see the full compilation log."
+            msg += f"\nOptions: {' '.join(final_options)}\n"
+            raise RuntimeError(msg)
+
+        bitcode_size = ctypes.c_size_t()
+        result = mcrtc.mcrtcGetBitcodeSize(program, ctypes.byref(bitcode_size))
+        assert result == MCRTC_SUCCESS, f"Failed to get bitcode size: {get_mcrtc_error_string(result)}"
+
+        result_buffer = ctypes.create_string_buffer(bitcode_size.value)
+        result = mcrtc.mcrtcGetBitcode(program, result_buffer)
+        assert result == MCRTC_SUCCESS, f"Failed to get bitcode: {get_mcrtc_error_string(result)}"
+
+        return result_buffer.raw
+
+    finally:
+        result = mcrtc.mcrtcDestroyProgram(ctypes.byref(program))
+        assert result == MCRTC_SUCCESS, f"Failed to destroy program: {get_mcrtc_error_string(result)}"

--- a/tilelang/jit/__init__.py
+++ b/tilelang/jit/__init__.py
@@ -91,7 +91,7 @@ class _CallFormCache:
 def compile(
     func: PrimFunc[_KP, _T] = None,
     out_idx: list[int] | int | None = None,
-    execution_backend: Literal["auto", "tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"] | None = None,
+    execution_backend: Literal["auto", "tvm_ffi", "cython", "nvrtc", "mcrtc", "torch", "cutedsl"] | None = None,
     target: TargetLike | None = None,
     target_host: TargetLike | None = None,
     verbose: bool | None = None,
@@ -107,7 +107,7 @@ def compile(
         The TileLang TIR function to compile and wrap.
     out_idx : Union[List[int], int], optional
         Index(es) of the output tensors to return (default: None).
-    execution_backend : Literal["auto", "tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"], optional
+    execution_backend : Literal["auto", "tvm_ffi", "cython", "nvrtc", "mcrtc", "torch", "cutedsl"], optional
         Execution backend to use for kernel execution. If None, reads from
         TILELANG_EXECUTION_BACKEND environment variable (defaults to "auto").
     target : str, dict, or tvm.target.Target, optional
@@ -173,7 +173,7 @@ def compile(
 def par_compile(
     funcs: Iterable[PrimFunc[_KP, _T]],
     out_idx: list[int] | int | None = None,
-    execution_backend: Literal["auto", "tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"] | None = None,
+    execution_backend: Literal["auto", "tvm_ffi", "cython", "nvrtc", "mcrtc", "torch", "cutedsl"] | None = None,
     target: TargetLike | None = None,
     target_host: TargetLike | None = None,
     verbose: bool | None = None,
@@ -191,7 +191,7 @@ def par_compile(
         The TileLang TIR functions to compile and wrap.
     out_idx : Union[List[int], int], optional
         Index(es) of the output tensors to return (default: None).
-    execution_backend : Literal["auto", "tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"], optional
+    execution_backend : Literal["auto", "tvm_ffi", "cython", "nvrtc", "mcrtc", "torch", "cutedsl"], optional
         Execution backend to use for kernel execution. If None, reads from
         TILELANG_EXECUTION_BACKEND environment variable (defaults to "auto").
     target : str, dict, or tvm.target.Target, optional
@@ -329,7 +329,7 @@ class JITImpl(Generic[_P, _KP, _T, _Ret]):
     """
 
     out_idx: list[int] | int | None
-    execution_backend: Literal["auto", "tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"] | None
+    execution_backend: Literal["auto", "tvm_ffi", "cython", "nvrtc", "mcrtc", "torch", "cutedsl"] | None
     target: TargetLike | None
     target_host: TargetLike | None
     verbose: bool | None
@@ -540,7 +540,7 @@ class JITImpl(Generic[_P, _KP, _T, _Ret]):
             return kernel
 
 
-ExecutionBackend = Literal["auto", "tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"]
+ExecutionBackend = Literal["auto", "tvm_ffi", "cython", "nvrtc", "mcrtc", "torch", "cutedsl"]
 
 
 @overload

--- a/tilelang/jit/adapter/__init__.py
+++ b/tilelang/jit/adapter/__init__.py
@@ -2,5 +2,6 @@ from .base import BaseKernelAdapter, CachedTextSource  # noqa: F401
 from .tvm_ffi import TVMFFIKernelAdapter  # noqa: F401
 from .cython import CythonKernelAdapter  # noqa: F401
 from .nvrtc import NVRTCKernelAdapter  # noqa: F401
+from .mcrtc import MCRTCKernelAdapter  # noqa: F401
 from .torch import MetalKernelAdapter  # noqa: F401
 from .cutedsl import CuTeDSLKernelAdapter  # noqa: F401

--- a/tilelang/jit/adapter/mcrtc/__init__.py
+++ b/tilelang/jit/adapter/mcrtc/__init__.py
@@ -1,0 +1,64 @@
+"""MCRTC Backend for TileLang.
+
+This module provides runtime compilation support using MACA's MCRTC API.
+"""
+
+import logging
+
+__all__ = [
+    "MCRTCKernelAdapter",
+    "TLMCRTCSourceWrapper",
+    "MCRTCLibraryGenerator",
+    "is_mcrtc_available",
+    "check_mcrtc_available",
+]
+
+logger = logging.getLogger(__name__)
+
+is_mcrtc_available = False
+MCRTC_UNAVAILABLE_MESSAGE = (
+    "MACA MCRTC runtime is not available, MCRTC backend cannot be used. "
+    "Please make sure MACA_PATH is configured and libmcruntime.so can be loaded."
+)
+
+try:
+    from tilelang.contrib.mcrtc import mcrtc  # noqa: F401
+
+    is_mcrtc_available = True
+except (ImportError, OSError) as e:
+    logger.debug(f"MCRTC runtime import failed: {e}")
+
+
+def check_mcrtc_available():
+    """Check if MCRTC backend is available."""
+    if not is_mcrtc_available:
+        raise ImportError(MCRTC_UNAVAILABLE_MESSAGE)
+
+
+if is_mcrtc_available:
+    from .adapter import MCRTCKernelAdapter
+    from .libgen import MCRTCLibraryGenerator
+    from .wrapper import TLMCRTCSourceWrapper
+else:
+
+    class MCRTCKernelAdapter:
+        """Dummy MCRTCKernelAdapter that raises ImportError."""
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(MCRTC_UNAVAILABLE_MESSAGE)
+
+        @classmethod
+        def from_database(cls, *args, **kwargs):
+            raise ImportError(MCRTC_UNAVAILABLE_MESSAGE)
+
+    class TLMCRTCSourceWrapper:
+        """Dummy TLMCRTCSourceWrapper that raises ImportError."""
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(MCRTC_UNAVAILABLE_MESSAGE)
+
+    class MCRTCLibraryGenerator:
+        """Dummy MCRTCLibraryGenerator that raises ImportError."""
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(MCRTC_UNAVAILABLE_MESSAGE)

--- a/tilelang/jit/adapter/mcrtc/adapter.py
+++ b/tilelang/jit/adapter/mcrtc/adapter.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+import torch
+from tvm import tirx
+from tvm.target import Target
+
+from tilelang import tvm as tvm
+from tilelang.backend.target import determine_target
+from tilelang.engine.param import KernelParam
+from tilelang.jit.adapter.base import BaseKernelAdapter, CachedTextSource
+from tilelang.jit.adapter.mcrtc import check_mcrtc_available
+from tilelang.utils.language import retrieve_func_from_module
+
+from .driver import get_function
+from .libgen import MCRTCLibraryGenerator
+from .wrapper import TLMCRTCSourceWrapper
+
+logger = logging.getLogger(__name__)
+
+
+class MCRTCKernelAdapter(BaseKernelAdapter):
+    pymodule = None
+
+    def __init__(
+        self,
+        params: list[KernelParam],
+        result_idx: list[int],
+        target: str | Target,
+        func_or_mod: tirx.PrimFunc | tvm.IRModule,
+        host_mod: tvm.IRModule | None = None,
+        device_mod: tvm.IRModule | None = None,
+        device_kernel_source: str | None = None,
+        verbose: bool = False,
+        pass_configs: dict[str, Any] | None = None,
+        compile_flags: list[str] | None = None,
+    ):
+        check_mcrtc_available()
+
+        self.params = params
+        self.result_idx = self._legalize_result_idx(result_idx)
+        self.device_kernel_source = device_kernel_source
+        self.kernels = {}
+
+        if isinstance(func_or_mod, tirx.PrimFunc):
+            self.ir_module = tvm.IRModule({func_or_mod.attrs["global_symbol"]: func_or_mod})
+        else:
+            self.ir_module = func_or_mod
+
+        self.param_dtypes = [param.torch_dtype() for param in params]
+        self.param_shapes = []
+        for param in params:
+            native_shape = []
+            for dim in param.shape:
+                if isinstance(dim, tirx.IntImm):
+                    native_shape.append(int(dim))
+                elif isinstance(dim, tirx.Var):
+                    native_shape.append(dim)
+                else:
+                    native_shape.append(dim)
+            self.param_shapes.append(native_shape)
+
+        self.dynamic_symbolic_map = self._process_dynamic_symbolic()
+        self.target = Target(determine_target(target))
+        self.verbose = verbose
+
+        self.wrapper = TLMCRTCSourceWrapper(
+            self.ir_module,
+            device_kernel_source,
+            self.target,
+            device_mod=device_mod,
+            host_mod=host_mod,
+            pass_configs=pass_configs,
+        )
+        wrapper_result = self.wrapper.wrap()
+
+        self.host_func = wrapper_result["host_func"]
+        self.function_names = wrapper_result["function_names"]
+
+        self.lib_generator = MCRTCLibraryGenerator(self.target, self.verbose)
+        self.lib_generator.update_lib_code(self.device_kernel_source)
+        self.lib_generator.update_host_func(self.host_func)
+        self.lib_generator.assign_compile_flags(compile_flags)
+        self.lib_generator.compile_lib()
+        self.lib_generator.load_lib()
+
+        self.libpath = self.lib_generator.libpath
+        self.pymodule = self.lib_generator.pymodule
+
+        module = self.lib_generator.module
+        for name in self.function_names:
+            self.kernels[name] = get_function(module, name)
+
+        self._post_init()
+
+    @classmethod
+    def from_database(
+        cls,
+        params: list[KernelParam],
+        result_idx: list[int],
+        target: str,
+        func_or_mod: tirx.PrimFunc | tvm.IRModule,
+        host_kernel_source: CachedTextSource,
+        device_kernel_source: CachedTextSource,
+        kernel_lib_path: str,
+        verbose: bool = False,
+        pass_configs: dict[str, Any] | None = None,
+        compile_flags: list[str] | None = None,
+    ):
+        check_mcrtc_available()
+
+        adapter = cls.__new__(cls)
+        adapter.params = params
+        adapter.result_idx = adapter._legalize_result_idx(result_idx)
+        adapter.kernels = {}
+
+        adapter._set_cached_text_source(
+            "host_func",
+            "_host_kernel_source_path",
+            host_kernel_source,
+        )
+        adapter.host_kernel_source = host_kernel_source.text
+        adapter._set_cached_text_source(
+            "device_kernel_source",
+            "_device_kernel_source_path",
+            device_kernel_source,
+        )
+
+        if isinstance(func_or_mod, tirx.PrimFunc):
+            adapter.ir_module = tvm.IRModule({func_or_mod.attrs["global_symbol"]: func_or_mod})
+        else:
+            adapter.ir_module = func_or_mod
+
+        adapter.param_dtypes = [param.torch_dtype() for param in params]
+        adapter.param_shapes = []
+        for param in params:
+            native_shape = []
+            for dim in param.shape:
+                if isinstance(dim, tirx.IntImm):
+                    native_shape.append(int(dim))
+                elif isinstance(dim, tirx.Var):
+                    native_shape.append(dim)
+                else:
+                    native_shape.append(dim)
+            adapter.param_shapes.append(native_shape)
+
+        adapter.dynamic_symbolic_map = adapter._process_dynamic_symbolic()
+        adapter.target = Target(determine_target(target))
+        adapter.verbose = verbose
+
+        adapter.lib_generator = MCRTCLibraryGenerator(adapter.target, adapter.verbose)
+        adapter.lib_generator.assign_compile_flags(compile_flags)
+        adapter.lib_generator.load_lib(lib_path=kernel_lib_path)
+
+        adapter.libpath = kernel_lib_path
+        adapter.pymodule = adapter.lib_generator.pymodule
+        adapter.function_names = adapter.pymodule._function_names
+
+        module = adapter.lib_generator.module
+        for name in adapter.function_names:
+            adapter.kernels[name] = get_function(module, name)
+
+        adapter._post_init()
+        return adapter
+
+    def _process_dynamic_symbolic(self) -> dict[tirx.Var, tuple[int, int]]:
+        """Map dynamic variables to their source tensor and shape dimension."""
+        func = self.prim_func
+        params = func.params
+        buffer_map = func.buffer_map
+        dynamic_symbolic_map = {}
+        self._dynamic_symbolic_name_map: dict[str, tuple[int, int]] = {}
+
+        for param_index, param in enumerate(params):
+            buffer = buffer_map[param]
+            for shape_index, shape in enumerate(buffer.shape):
+                if isinstance(shape, tirx.Var) and shape not in dynamic_symbolic_map:
+                    dynamic_symbolic_map[shape] = (param_index, shape_index)
+                    self._dynamic_symbolic_name_map[shape.name] = (param_index, shape_index)
+
+        return dynamic_symbolic_map
+
+    def _lookup_dynamic_symbolic(self, variable: tirx.Var) -> tuple[int, int]:
+        """Find the source tensor and dimension for a dynamic variable."""
+        if variable in self.dynamic_symbolic_map:
+            return self.dynamic_symbolic_map[variable]
+        if variable.name in self._dynamic_symbolic_name_map:
+            return self._dynamic_symbolic_name_map[variable.name]
+        raise KeyError(f"Dynamic symbolic variable '{variable.name}' was not found.")
+
+    def get_kernel_source(self, kernel_only: bool = True) -> str | None:
+        """Return cached MACA kernel source or generated host source."""
+        if kernel_only:
+            return self._load_cached_text_source(
+                "device_kernel_source",
+                "_device_kernel_source_path",
+            )
+        return self._load_cached_text_source(
+            "host_func",
+            "_host_kernel_source_path",
+        )
+
+    def get_host_source(self) -> str | None:
+        """Return generated Python launch source."""
+        return self._load_cached_text_source(
+            "host_func",
+            "_host_kernel_source_path",
+        )
+
+    def _forward_from_prebuild_lib(self, *args, stream: int | None = None):
+        """Invoke the generated Python launcher."""
+        return self.pymodule.call(self.kernels, *args, stream=stream)
+
+    def _wrap_forward_from_prebuild_lib(
+        self,
+        *ins: list[torch.Tensor],
+        stream: int | None = None,
+    ):
+        """Validate inputs, allocate outputs and launch the MACA kernel."""
+        if len(ins) + len(self.result_idx) != len(self.params):
+            raise ValueError(
+                f"Expected {len(self.params)} inputs, got "
+                f"{len(ins) + len(self.result_idx)} with {len(ins)} inputs "
+                f"and {len(self.result_idx)} outputs."
+            )
+
+        input_index = 0
+        args = []
+
+        for index in range(len(self.params)):
+            if index in self.result_idx:
+                dtype = self.param_dtypes[index]
+                shape = []
+
+                for dim in self.param_shapes[index]:
+                    if isinstance(dim, tirx.Var):
+                        tensor_index, shape_index = self._lookup_dynamic_symbolic(dim)
+                        shape.append(ins[tensor_index].shape[shape_index])
+                    else:
+                        shape.append(dim)
+
+                device = ins[0].device if len(ins) > 0 else torch.cuda.current_device()
+                tensor = torch.empty(*shape, dtype=dtype, device=device)
+            else:
+                tensor = ins[input_index]
+                input_index += 1
+
+            args.append(tensor)
+
+        for _, (buffer_index, shape_index) in self.dynamic_symbolic_map.items():
+            args.append(args[buffer_index].shape[shape_index])
+
+        if stream is None:
+            if torch.cuda.is_available():
+                stream = int(torch.cuda.current_stream().cuda_stream)
+            else:
+                stream = 0
+
+        self._forward_from_prebuild_lib(*args, stream=stream)
+
+        if len(self.result_idx) == 1:
+            return args[self.result_idx[0]]
+        return [args[index] for index in self.result_idx]
+
+    def _convert_torch_func(
+        self,
+    ) -> Callable[..., torch.Tensor | list[torch.Tensor]]:
+        """Return a PyTorch-compatible callable."""
+        return self._wrap_forward_from_prebuild_lib
+
+    @property
+    def prim_func(self) -> tirx.PrimFunc:
+        """Return the primary TIR function from the IRModule."""
+        return retrieve_func_from_module(self.ir_module)

--- a/tilelang/jit/adapter/mcrtc/driver.py
+++ b/tilelang/jit/adapter/mcrtc/driver.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import ctypes
+
+from tilelang.contrib.mcrtc import mcrtc
+
+
+MC_SUCCESS = 0
+
+mcrtc.mcGetErrorName.argtypes = [ctypes.c_int]
+mcrtc.mcGetErrorName.restype = ctypes.c_char_p
+
+mcrtc.mcGetErrorString.argtypes = [ctypes.c_int]
+mcrtc.mcGetErrorString.restype = ctypes.c_char_p
+
+mcrtc.mcModuleLoadData.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_void_p]
+mcrtc.mcModuleLoadData.restype = ctypes.c_int
+
+mcrtc.mcModuleGetFunction.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_void_p, ctypes.c_char_p]
+mcrtc.mcModuleGetFunction.restype = ctypes.c_int
+
+mcrtc.mcModuleUnload.argtypes = [ctypes.c_void_p]
+mcrtc.mcModuleUnload.restype = ctypes.c_int
+
+mcrtc.mcModuleLaunchKernel.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_uint,
+    ctypes.c_uint,
+    ctypes.c_uint,
+    ctypes.c_uint,
+    ctypes.c_uint,
+    ctypes.c_uint,
+    ctypes.c_uint,
+    ctypes.c_void_p,
+    ctypes.POINTER(ctypes.c_void_p),
+    ctypes.POINTER(ctypes.c_void_p),
+]
+mcrtc.mcModuleLaunchKernel.restype = ctypes.c_int
+
+
+def get_error_string(result: int) -> str:
+    name = mcrtc.mcGetErrorName(result)
+    message = mcrtc.mcGetErrorString(result)
+    name = name.decode("utf-8") if name else f"mcError({result})"
+    message = message.decode("utf-8") if message else "Unknown MACA runtime error"
+    return f"{name}: {message}"
+
+
+def check_error(result: int, operation: str):
+    if result != MC_SUCCESS:
+        raise RuntimeError(f"{operation} failed: {get_error_string(result)}")
+
+
+def load_module(bitcode: bytes) -> ctypes.c_void_p:
+    module = ctypes.c_void_p()
+    bitcode_buffer = (ctypes.c_char * len(bitcode)).from_buffer_copy(bitcode)
+    result = mcrtc.mcModuleLoadData(ctypes.byref(module), ctypes.cast(bitcode_buffer, ctypes.c_void_p))
+    check_error(result, "mcModuleLoadData")
+    return module
+
+
+def get_function(module: ctypes.c_void_p, function_name: str) -> ctypes.c_void_p:
+    function = ctypes.c_void_p()
+    result = mcrtc.mcModuleGetFunction(ctypes.byref(function), module, function_name.encode("utf-8"))
+    check_error(result, "mcModuleGetFunction")
+    return function
+
+
+def unload_module(module: ctypes.c_void_p):
+    result = mcrtc.mcModuleUnload(module)
+    check_error(result, "mcModuleUnload")
+
+
+def launch_kernel(
+    function: ctypes.c_void_p,
+    grid_dim: tuple[int, int, int],
+    block_dim: tuple[int, int, int],
+    shared_mem_bytes: int,
+    stream: int | ctypes.c_void_p | None,
+    args: list[ctypes._SimpleCData],
+):
+    """Launch a MACA kernel with ctypes-packed arguments."""
+    grid_x, grid_y, grid_z = (int(value) for value in grid_dim)
+    block_x, block_y, block_z = (int(value) for value in block_dim)
+    stream_handle = stream if isinstance(stream, ctypes.c_void_p) else ctypes.c_void_p(stream or 0)
+
+    arg_ptrs = (ctypes.c_void_p * len(args))()
+    for index, arg in enumerate(args):
+        arg_ptrs[index] = ctypes.cast(ctypes.pointer(arg), ctypes.c_void_p)
+
+    result = mcrtc.mcModuleLaunchKernel(
+        function,
+        grid_x,
+        grid_y,
+        grid_z,
+        block_x,
+        block_y,
+        block_z,
+        int(shared_mem_bytes),
+        stream_handle,
+        arg_ptrs,
+        None,
+    )
+    check_error(result, "mcModuleLaunchKernel")

--- a/tilelang/jit/adapter/mcrtc/kernel_cache.py
+++ b/tilelang/jit/adapter/mcrtc/kernel_cache.py
@@ -1,0 +1,21 @@
+import os
+
+from tilelang.cache.kernel_cache import KernelCache
+from tilelang.jit import JITKernel
+
+
+class MCRTCKernelCache(KernelCache):
+    kernel_lib_path = "kernel.mcbin"
+    kernel_py_path = "kernel.py"
+
+    def _get_required_files(self, cache_path: str) -> list[str]:
+        return super()._get_required_files(cache_path) + [os.path.join(cache_path, self.kernel_py_path)]
+
+    def _save_so_cubin_to_disk(self, kernel: JITKernel, cache_path: str, verbose: bool = False):
+        src_lib_path = kernel.adapter.libpath
+        kernel_py_path = os.path.join(cache_path, self.kernel_py_path)
+        src_lib_path = src_lib_path.replace(".mcbin", ".py")
+        if verbose:
+            self.logger.debug(f"Saving kernel mcrtc python code to file: {kernel_py_path}")
+        KernelCache._safe_write_file(kernel_py_path, "wb", lambda file: file.write(KernelCache._load_binary(src_lib_path)))
+        super()._save_so_cubin_to_disk(kernel, cache_path, verbose)

--- a/tilelang/jit/adapter/mcrtc/libgen.py
+++ b/tilelang/jit/adapter/mcrtc/libgen.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import importlib.util
+import logging
+import tempfile
+from types import ModuleType
+from typing import Any
+
+from tvm.target import Target
+
+from tilelang.jit.adapter.libgen import LibraryGenerator
+from tilelang.contrib.mcrtc import compile_maca
+from tilelang.jit.adapter.mcrtc import check_mcrtc_available
+from tilelang.jit.adapter.mcrtc.driver import load_module, unload_module
+
+logger = logging.getLogger(__name__)
+
+
+class MCRTCLibraryGenerator(LibraryGenerator):
+    """Runtime compiler and loader for MCRTC-compiled MACA kernels."""
+
+    host_func: str | None = None
+    module: Any = None
+    pymodule: ModuleType | None = None
+    pypath: str | None = None
+
+    def __init__(self, target: Target, verbose: bool = False):
+        check_mcrtc_available()
+        super().__init__(target, verbose)
+
+    @staticmethod
+    def import_from_file(module_name: str, file_path: str) -> ModuleType:
+        spec = importlib.util.spec_from_file_location(module_name, file_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Failed to create module spec from {file_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def update_host_func(self, host_func: str):
+        self.host_func = host_func
+
+    def load_lib(self, lib_path: str | None = None):
+        if lib_path is None:
+            lib_path = self.libpath
+        else:
+            self.libpath = lib_path
+
+        self.pypath = lib_path.replace(".mcbin", ".py")
+        self.pymodule = self.import_from_file("kernel", self.pypath)
+
+        with open(lib_path, "rb") as f:
+            bitcode = f.read()
+
+        self.module = load_module(bitcode)
+
+    def compile_lib(self, timeout: float | None = None):
+        if self.host_func is None:
+            raise RuntimeError("Host function is not set, please call update_host_func() first.")
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".maca", delete=False) as src:
+            src.write(self.lib_code)
+            self.srcpath = src.name
+
+        self.libpath = self.srcpath.replace(".maca", ".mcbin")
+        self.pypath = self.srcpath.replace(".maca", ".py")
+        options = [item for flag in self.compile_flags for item in flag.split()] if self.compile_flags else []
+        bitcode = compile_maca(self.lib_code, options=options, verbose=True)
+
+        with open(self.libpath, "wb") as f:
+            f.write(bitcode)
+
+        with open(self.pypath, "w") as f:
+            f.write(self.host_func)
+
+    def __del__(self):
+        if self.module is not None:
+            try:
+                unload_module(self.module)
+            except Exception as e:
+                logger.debug(f"Failed to unload MACA module: {e}")
+            self.module = None

--- a/tilelang/jit/adapter/mcrtc/wrapper.py
+++ b/tilelang/jit/adapter/mcrtc/wrapper.py
@@ -1,0 +1,212 @@
+"""MCRTC Source Wrapper for TileLang.
+
+Generates Python runtime code for launching MACA kernels compiled via MCRTC.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import Any, ClassVar
+
+from tvm import IRModule
+from tvm.target import Target
+from tvm.tirx.stmt_functor import post_order_visit
+
+from tilelang import tvm as tvm
+from tilelang.jit.adapter.wrapper import TLCUDASourceWrapper
+from tilelang.jit.adapter.utils import match_declare_kernel, parse_function_call_args, pythonic_expr
+
+
+PREDEFINED_HOST_FUNC_PY = """from tilelang.jit.adapter.mcrtc.driver import launch_kernel
+import ctypes
+
+_function_names = {0}
+
+def call({1}):
+{2}
+"""
+
+
+KERNEL_LAUNCH_FUNC_PY = """launch_kernel(
+    kernels['{0}'],
+    ({1}, {2}, {3}),
+    ({4}, {5}, {6}),
+    {7},
+    stream,
+    [{8}],
+)
+"""
+
+
+class TLMCRTCSourceWrapper(TLCUDASourceWrapper):
+    """MCRTC backend wrapper that generates Python kernel launch code."""
+
+    _TYPE_MAP: ClassVar[dict[str, str]] = {
+        "float32": "ctypes.c_float",
+        "float16": "ctypes.c_uint16",
+        "bfloat16": "ctypes.c_uint16",
+        "float8_e4m3": "ctypes.c_uint8",
+        "float8_e4m3fn": "ctypes.c_uint8",
+        "float8_e5m2": "ctypes.c_uint8",
+        "float64": "ctypes.c_double",
+        "int64": "ctypes.c_int64",
+        "int32": "ctypes.c_int32",
+        "uint32": "ctypes.c_uint32",
+        "bool": "ctypes.c_bool",
+        "int8": "ctypes.c_int8",
+        "uint8": "ctypes.c_uint8",
+        "int16": "ctypes.c_int16",
+        "uint16": "ctypes.c_uint16",
+        "uchar": "ctypes.c_uint8",
+    }
+
+    def __init__(
+        self,
+        scheduled_ir_module: IRModule,
+        source: str,
+        target: Target,
+        device_mod: IRModule | None = None,
+        host_mod: IRModule | None = None,
+        pass_configs: dict[str, Any] | None = None,
+    ):
+        super().__init__(scheduled_ir_module, source, target, device_mod, host_mod, pass_configs)
+
+    def _pythonic_expr(self, expr: tvm.tir.PrimExpr) -> str:
+        return pythonic_expr(expr, self._TYPE_MAP, ignore_cast=True, floor_div_op="//")
+
+    def create_dispatch_func(self, code: str, function_informations: dict[str, dict]) -> str:
+        """Generate a Python function that packs arguments and launches MACA kernels."""
+        dynamic_symbolic_set = self.get_dynamic_symbolic_set(self.prim_func)
+        function_args = [{"name": "kernels", "type": "dict"}]
+
+        for param in self.prim_func.params:
+            if param in self.prim_func.buffer_map:
+                buffer = self.prim_func.buffer_map[param]
+                function_args.append({"name": buffer.data.name, "type": "ctypes.c_void_p"})
+            elif isinstance(param, tvm.tir.Var):
+                function_args.append({"name": param.name, "type": self._lookup_type(param.dtype)})
+            else:
+                raise ValueError(f"Parameter {param} is not in the buffer map of the primary function.")
+
+        for dyn_sym, dyn_sym_dtype in dynamic_symbolic_set:
+            if dyn_sym not in [arg["name"] for arg in function_args]:
+                function_args.append({"name": dyn_sym, "type": self._lookup_type(dyn_sym_dtype)})
+
+        function_args.append(self.get_stream_type())
+        def_args = ", ".join(arg["name"] for arg in function_args)
+        kernel_launch_code = ""
+
+        for function_name, function_info in function_informations.items():
+            block_info = function_info["block_info"]
+            grid_info = function_info["grid_info"]
+            dynamic_smem_buf = function_info["dynamic_smem_buf"]
+            function_params = function_info["function_params"]
+
+            index = match_declare_kernel(code, function_name + "(")
+            if index < 0:
+                raise ValueError(f"Cannot find kernel declaration for {function_name}.")
+
+            kernel_code = code[index:]
+            semicolon_pos = kernel_code.find(";")
+            brace_pos = kernel_code.find("{")
+
+            if semicolon_pos >= 0 and (brace_pos < 0 or semicolon_pos < brace_pos):
+                declaration = kernel_code[:semicolon_pos]
+            else:
+                declaration = kernel_code[:brace_pos]
+
+            def transform_mcrtc_arg(name: str, arg_type: str):
+                if arg_type == "ctypes.c_void_p":
+                    return f"{name}.data_ptr()", arg_type
+                return name, arg_type
+
+            call_args = parse_function_call_args(
+                declaration,
+                function_args,
+                function_params,
+                {},
+                {},
+                transform_mcrtc_arg,
+            )
+
+            if len(call_args) != len(function_params):
+                raise ValueError(
+                    f"Kernel {function_name} expects {len(function_params)} arguments, "
+                    f"but {len(call_args)} launch arguments were generated."
+                )
+            arg_values = ", ".join(f"{arg_type}({arg_name})" for arg_name, arg_type in call_args)
+            shared_mem = self._pythonic_expr(dynamic_smem_buf) if dynamic_smem_buf is not None else "0"
+
+            kernel_launch_code += KERNEL_LAUNCH_FUNC_PY.format(
+                function_name,
+                self._pythonic_expr(grid_info[0]),
+                self._pythonic_expr(grid_info[1]),
+                self._pythonic_expr(grid_info[2]),
+                self._pythonic_expr(block_info[0]),
+                self._pythonic_expr(block_info[1]),
+                self._pythonic_expr(block_info[2]),
+                shared_mem,
+                arg_values,
+            )
+
+        body = kernel_launch_code.strip() or "pass"
+        return PREDEFINED_HOST_FUNC_PY.format(
+            repr(list(function_informations.keys())),
+            def_args,
+            textwrap.indent(body, "    "),
+        )
+
+    def update_lib_code(self, code: str):
+        """Update MACA source code and generate the Python host dispatcher."""
+        self.lib_code = code
+        function_informations = {}
+
+        for function_name in self.function_names:
+            if function_name not in self.block_info or function_name not in self.grid_info:
+                continue
+            if self.device_mod is None:
+                raise RuntimeError("Device IRModule is required to generate MCRTC launch code.")
+            if function_name not in self.device_mod:
+                raise ValueError(f"Function {function_name} was not found in the device module.")
+
+            device_func = self.device_mod[function_name]
+            kernel_params_count = len(device_func.params)
+            function_params = None
+
+            def visitor(node, fn=function_name, param_count=kernel_params_count):
+                nonlocal function_params
+                if not isinstance(node, tvm.tirx.Call):
+                    return
+                if not (hasattr(node, "op") and node.op == tvm.ir.Op.get("tirx.tvm_call_packed")):
+                    return
+
+                args = node.args
+                if not args or args[0] != fn:
+                    return
+                if len(args) < 1 + param_count:
+                    raise AssertionError(f"Kernel call for {fn} requires {param_count} arguments, but only {len(args) - 1} were found.")
+                function_params = args[1 : 1 + param_count]
+
+            post_order_visit(self.host_func.body, visitor)
+            if function_params is None:
+                raise ValueError(f"Cannot find packed call arguments for kernel {function_name}.")
+
+            function_informations[function_name] = {
+                "function_name": function_name,
+                "block_info": self.block_info[function_name],
+                "grid_info": self.grid_info[function_name],
+                "dynamic_smem_buf": self.dynamic_smem_buf[function_name],
+                "function_params": function_params,
+            }
+
+        self._host_func = self.create_dispatch_func(code, function_informations)
+        return self.lib_code
+
+    def wrap(self):
+        return {
+            "host_func": self._host_func,
+            "function_names": self.function_names,
+        }
+
+    def get_stream_type(self) -> dict[str, str]:
+        return {"name": "stream", "type": "int"}

--- a/tilelang/jit/adapter/wrapper.py
+++ b/tilelang/jit/adapter/wrapper.py
@@ -1185,6 +1185,10 @@ class TLPyWrapper(TLWrapper):
             from tilelang.jit.adapter.cutedsl import TLCuTeDSLSourceWrapper
 
             wrapper_class = TLCuTeDSLSourceWrapper
+        elif is_maca_target(self.target):
+            from tilelang.jit.adapter.mcrtc import TLMCRTCSourceWrapper
+
+            wrapper_class = TLMCRTCSourceWrapper
         elif is_cuda_target(self.target):
             from tilelang.jit.adapter.nvrtc import TLNVRTCSourceWrapper
 

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -67,7 +67,7 @@ class JITKernel(Generic[_P, _T]):
         self,
         func: PrimFunc = None,
         out_idx: list[int] | int = None,
-        execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"] = "tvm_ffi",
+        execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "mcrtc", "torch", "cutedsl"] = "tvm_ffi",
         target: TargetLike = "auto",
         target_host: TargetLike | None = None,
         verbose: bool = False,
@@ -84,7 +84,7 @@ class JITKernel(Generic[_P, _T]):
             The TileLang TIR function to compile and wrap.
         out_idx : Union[List[int], int], optional
             Index(es) of the output tensors to return (default: None).
-        execution_backend : Literal["tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"], optional
+        execution_backend : Literal["tvm_ffi", "cython", "nvrtc", "mcrtc", "torch", "cutedsl"], optional
             Execution backend to use for kernel execution.
         target : str, dict, or tvm.target.Target, optional
             Compilation target (default: "auto"). Use a dict for target attributes,
@@ -153,7 +153,7 @@ class JITKernel(Generic[_P, _T]):
         target: TargetLike,
         target_host: TargetLike | None,
         out_idx: list[int] | int,
-        execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"],
+        execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "mcrtc", "torch", "cutedsl"],
         pass_configs: dict[str, Any] | None = None,
         compile_flags: list[str] | None = None,
     ):
@@ -337,6 +337,22 @@ class JITKernel(Generic[_P, _T]):
                 pass_configs=pass_configs,
                 compile_flags=compile_flags,
             )
+        elif execution_backend == "mcrtc":
+            from tilelang.jit.adapter import MCRTCKernelAdapter
+
+            adapter = create_adapter(
+                MCRTCKernelAdapter,
+                params=artifact.params,
+                result_idx=out_idx,
+                target=target,
+                func_or_mod=tilelang_func,
+                host_mod=artifact.host_mod,
+                device_mod=artifact.device_mod,
+                device_kernel_source=artifact.kernel_source,
+                verbose=verbose,
+                pass_configs=pass_configs,
+                compile_flags=compile_flags,
+            )
         elif execution_backend == "torch":
             assert is_metal_target(target)
             adapter = create_adapter(
@@ -429,6 +445,20 @@ class JITKernel(Generic[_P, _T]):
                 pass_configs=pass_configs,
                 compile_flags=compile_flags,
             )
+        elif execution_backend == "mcrtc":
+            from tilelang.jit.adapter import MCRTCKernelAdapter
+
+            adapter = MCRTCKernelAdapter.from_database(
+                params=params,
+                result_idx=result_idx,
+                target=target,
+                func_or_mod=func_or_mod,
+                host_kernel_source=host_kernel_source,
+                device_kernel_source=device_kernel_source,
+                kernel_lib_path=kernel_lib_path,
+                pass_configs=pass_configs,
+                compile_flags=compile_flags,
+            )
         elif execution_backend == "cutedsl":
             adapter = CuTeDSLKernelAdapter.from_database(
                 params=params,
@@ -491,7 +521,7 @@ class JITKernel(Generic[_P, _T]):
         str
             The source code of the compiled kernel function.
         """
-        if self.execution_backend in {"cython", "nvrtc", "tvm_ffi", "cutedsl"}:
+        if self.execution_backend in {"cython", "nvrtc", "mcrtc", "tvm_ffi", "cutedsl"}:
             return self.adapter.get_kernel_source(kernel_only=kernel_only)
         return self.artifact.kernel_source
 
@@ -499,7 +529,7 @@ class JITKernel(Generic[_P, _T]):
         """
         Returns the source code of the host function.
         """
-        if self.execution_backend in {"cython", "nvrtc", "tvm_ffi", "cutedsl"}:
+        if self.execution_backend in {"cython", "nvrtc", "mcrtc", "tvm_ffi", "cutedsl"}:
             return self.adapter.get_host_source()
         assert self.artifact.host_mod is not None, "host_mod is not available"
         return str(self.artifact.host_mod)


### PR DESCRIPTION
Summary
This PR adds MACA Runtime Compilation (MCRTC) backend support to the TileLang JIT.

Changes
Add MCRTC runtime compilation, module loading, and kernel launch support.
Add the MCRTC adapter, source wrapper, library generator, driver, and kernel cache.
Integrate the MCRTC backend with the TileLang JIT, autotuner, and cache workflow.
Update the MACA codegen, templates, and intrinsics for runtime compilation.
Extend the existing JIT tests to validate MCRTC compilation and execution.

Test
python -m pytest testing/python/jit/test_tilelang_jit_nvrtc.py -vv -s
All tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added MCRTC runtime compilation, module loading, and kernel launch support.
- Added MCRTC adapter, source wrapper, library generator, driver, and kernel cache.
- Integrated `mcrtc` with the JIT, autotuner, cache workflow, and public backend APIs.
- Updated MACA code generation, templates, intrinsics, and numeric-limit handling.
- Replaced NVRTC coverage with MCRTC coverage in the JIT tests.
- The specified JIT test suite passed successfully.

## C++ style / lint notes

- The PR changes C++ code and MACA C++ templates.
- The rules in `docs/developer_guide/cpp_style.md` were not changed.
- No correctness or build issue is reported.
- The summary does not identify changes to the “C++ API Style Audit (warning only)” CI step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->