### PR TITLE
[fix bug][MetaXGPU] support mma for new arch

### DIFF
--- a/tilelang/maca/intrinsics/macro/mma_macro_generator.py
+++ b/tilelang/maca/intrinsics/macro/mma_macro_generator.py
@@ -137,12 +137,12 @@ class TensorCoreIntrinEmitter:
         elif a_dtype.bits == 16:
             self.k_dim = 16
         elif a_dtype.bits == 8:
-            if serial >= 1500 and serial <= 1600:
+            if serial >= 1500 and serial < 1700:
                 self.k_dim = 32
             elif serial >= 1000 and serial < 1500:
                 self.k_dim = 16
             else:
-                raise ValueError("Unsupported MetaXGPU Card")
+                raise ValueError(f"Unsupported MetaXGPU Card, arch={serial}")
         else:
             raise ValueError(f"Unsupported a_dtype = {a_dtype}")
 

--- a/tilelang/maca/intrinsics/macro/mma_sp_macro_generator.py
+++ b/tilelang/maca/intrinsics/macro/mma_sp_macro_generator.py
@@ -117,12 +117,12 @@ class SparseTensorCoreIntrinEmitter:
         elif a_dtype.bits == 16:
             self.k_dim = 16
         elif a_dtype.bits == 8:
-            if serial >= 1500 and serial <= 1600:
+            if serial >= 1500 and serial < 1700:
                 self.k_dim = 32
             elif serial >= 1000 and serial < 1500:
                 self.k_dim = 16
             else:
-                raise ValueError("Unsupported MetaXGPU Card")
+                raise ValueError(f"Unsupported MetaXGPU Card, arch={serial}")
         else:
             raise ValueError(f"Unsupported a_dtype = {a_dtype}")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Support MMA for MetaXGPU architectures with serials from `1500` through `1699`.
- Update 8-bit `k_dim` selection in both MMA macro generators.
- Include the detected architecture serial in unsupported-card errors.

## Testing

- Not reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->