### PR TITLE
[fix bug][MetaXGPU] fix test_tilelang_warp_sync.py case

### DIFF
--- a/src/maca/codegen/codegen_maca.cc
+++ b/src/maca/codegen/codegen_maca.cc
@@ -2538,7 +2538,8 @@ void CodeGenTileLangMACA::VisitExpr_(const CallNode *op, std::ostream &os) {
     // hide the out-parameter behind an immediately-invoked lambda and
     // discard pred (the returned mask already encodes whether all lanes
     // agreed: a non-zero result implies pred == 1).
-    os << "([&]() -> unsigned { int _tl_pred = 0; return __match_all_sync("
+    os << "([&]() -> unsigned long long { int _tl_pred = 0; return "
+          "__match_all_sync("
        << PrintExpr(op->args[0]) << ", " << PrintExpr(op->args[1])
        << ", &_tl_pred); }())";
   } else if (op->op.same_as(tl::get_lane_idx())) {

--- a/src/tl_templates/maca/common.h
+++ b/src/tl_templates/maca/common.h
@@ -344,6 +344,54 @@ public:
 };
 } // namespace tl
 
+// MACA does not provide native __shfl_*_sync overloads for TileLang's FP8
+// wrappers. Shuffle their byte storage through the native unsigned-int
+// overload so overload resolution is unambiguous and the bits are preserved.
+// Half and BF16 are deliberately omitted: the MACA SDK already provides exact
+// overloads for those native types.
+#define TL_DEFINE_MACA_SHFL_SYNC_OVERLOADS(TYPE, RAW)                          \
+  TL_PATCH TL_DEVICE TYPE __shfl_sync(maca_uint64_t mask, TYPE val,            \
+                                      int src_lane, int width = 64) {          \
+    RAW raw = static_cast<RAW>(val.v.__x);                                     \
+    RAW shuffled = static_cast<RAW>(                                           \
+        __shfl_sync(mask, static_cast<unsigned int>(raw), src_lane, width));   \
+    TYPE result;                                                               \
+    result.v.__x = static_cast<unsigned char>(shuffled);                       \
+    return result;                                                             \
+  }                                                                            \
+  TL_PATCH TL_DEVICE TYPE __shfl_xor_sync(maca_uint64_t mask, TYPE val,        \
+                                          int lane_mask, int width = 64) {     \
+    RAW raw = static_cast<RAW>(val.v.__x);                                     \
+    RAW shuffled = static_cast<RAW>(__shfl_xor_sync(                           \
+        mask, static_cast<unsigned int>(raw), lane_mask, width));              \
+    TYPE result;                                                               \
+    result.v.__x = static_cast<unsigned char>(shuffled);                       \
+    return result;                                                             \
+  }                                                                            \
+  TL_PATCH TL_DEVICE TYPE __shfl_down_sync(maca_uint64_t mask, TYPE val,       \
+                                           int delta, int width = 64) {        \
+    RAW raw = static_cast<RAW>(val.v.__x);                                     \
+    RAW shuffled = static_cast<RAW>(                                           \
+        __shfl_down_sync(mask, static_cast<unsigned int>(raw), delta, width)); \
+    TYPE result;                                                               \
+    result.v.__x = static_cast<unsigned char>(shuffled);                       \
+    return result;                                                             \
+  }                                                                            \
+  TL_PATCH TL_DEVICE TYPE __shfl_up_sync(maca_uint64_t mask, TYPE val,         \
+                                         int delta, int width = 64) {          \
+    RAW raw = static_cast<RAW>(val.v.__x);                                     \
+    RAW shuffled = static_cast<RAW>(                                           \
+        __shfl_up_sync(mask, static_cast<unsigned int>(raw), delta, width));   \
+    TYPE result;                                                               \
+    result.v.__x = static_cast<unsigned char>(shuffled);                       \
+    return result;                                                             \
+  }
+
+TL_DEFINE_MACA_SHFL_SYNC_OVERLOADS(tl::fp8_e4_t, uint8_t)
+TL_DEFINE_MACA_SHFL_SYNC_OVERLOADS(tl::fp8_e5_t, uint8_t)
+
+#undef TL_DEFINE_MACA_SHFL_SYNC_OVERLOADS
+
 namespace platform {
 
 template <typename T> struct numeric_limits : std::numeric_limits<T> {};

--- a/testing/python/language/test_tilelang_language_warp_sync.py
+++ b/testing/python/language/test_tilelang_language_warp_sync.py
@@ -40,9 +40,9 @@ def test_warp_sync():
 def kernel_with_shfl_sync():
     @T.prim_func
     def main(
-        A: T.Tensor((32,), "int32"),
+        A: T.Tensor((64,), "int32"),
     ):
-        with T.Kernel(1, threads=32):
+        with T.Kernel(1, threads=64):
             tx = T.get_thread_binding()
             val = tx * 10
             broadcast = T.shfl_sync(val, 31)
@@ -53,7 +53,7 @@ def kernel_with_shfl_sync():
 
 @tilelang.testing.requires_cuda
 def test_shfl_sync():
-    a = torch.empty((32), device="cuda", dtype=torch.int32)
+    a = torch.empty((64,), device="cuda", dtype=torch.int32)
     kernel = kernel_with_shfl_sync()
     assert "__shfl_sync" in kernel.get_kernel_source()
     kernel(a)
@@ -63,13 +63,13 @@ def test_shfl_sync():
 def _shift(lane, delta):
     """Return the source lane, or the current lane when the shift is out of range."""
     shifted = lane + delta
-    return shifted if 0 <= shifted < 32 else lane
+    return shifted if 0 <= shifted < 64 else lane
 
 
 # Builtin each shuffle lowers to and the lane its result comes from, in the row
 # order shfl_all_ops_kernel writes. The tables differ so the two shapes cannot fold.
 SHFL_TEMP_OPS = (
-    ("__shfl_sync", lambda lane: 31),
+    ("__shfl_sync", lambda lane: 63),
     ("__shfl_xor_sync", lambda lane: lane ^ 1),
     ("__shfl_down_sync", lambda lane: _shift(lane, 1)),
     ("__shfl_up_sync", lambda lane: _shift(lane, -1)),
@@ -84,20 +84,20 @@ SHFL_INLINE_OPS = (
 # One distinct value per lane so a wrong source lane cannot match by accident, on
 # float8_e5m2's coarse grid. Lane 0's negative zero needs the byte comparison.
 _MANTISSAS = (1.0, 1.25, 1.5, 1.75)
-_GRID = [sign * mant * 2.0**exp for exp in range(4) for mant in _MANTISSAS for sign in (1, -1)]
+_GRID = [sign * mant * 2.0**exp for exp in range(8) for mant in _MANTISSAS for sign in (1, -1)]
 LANE_VALUES = [-0.0, *_GRID[1:]]
 
 
 def shfl_all_ops_kernel(dtype):
     @T.prim_func
     def main(
-        A: T.Tensor((32,), dtype),
-        B: T.Tensor((len(SHFL_TEMP_OPS) + len(SHFL_INLINE_OPS), 32), dtype),
+        A: T.Tensor((64,), dtype),
+        B: T.Tensor((len(SHFL_TEMP_OPS) + len(SHFL_INLINE_OPS), 64), dtype),
     ):
-        with T.Kernel(1, threads=32):
+        with T.Kernel(1, threads=64):
             tx = T.get_thread_binding()
             # Rows 0-3 copy-initialize the result, rows 4-7 store it inline.
-            broadcast = T.shfl_sync(A[tx], 31)
+            broadcast = T.shfl_sync(A[tx], 63)
             swapped = T.shfl_xor(A[tx], 1)
             shifted_down = T.shfl_down(A[tx], 1)
             shifted_up = T.shfl_up(A[tx], 1)
@@ -113,7 +113,6 @@ def shfl_all_ops_kernel(dtype):
     return main
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize("dtype", [T.float16, T.bfloat16, T.float8_e4m3, T.float8_e5m2])
 def test_shfl_narrow_float_dtypes(dtype):
@@ -124,7 +123,7 @@ def test_shfl_narrow_float_dtypes(dtype):
     torch_dtype = dtype.as_torch()
     rows = len(SHFL_TEMP_OPS) + len(SHFL_INLINE_OPS)
     # out_idx would rebuild a torch tensor from float8 DLPack, unsupported on some versions.
-    b = torch.empty(rows, 32, device="cuda", dtype=torch_dtype)
+    b = torch.empty(rows, 64, device="cuda", dtype=torch_dtype)
     kernel(values.to(torch_dtype), b)
 
     # Both shapes must still reach the raw builtin, or these overloads stop being
@@ -135,7 +134,7 @@ def test_shfl_narrow_float_dtypes(dtype):
 
     for base, ops, form in ((0, SHFL_TEMP_OPS, "temporary"), (len(SHFL_TEMP_OPS), SHFL_INLINE_OPS, "inline")):
         for offset, (builtin, src_lane) in enumerate(ops):
-            ref = values[[src_lane(lane) for lane in range(32)]].to(torch_dtype)
+            ref = values[[src_lane(lane) for lane in range(64)]].to(torch_dtype)
             # Compare bytes: a float comparison would not separate -0.0 from +0.0.
             got_bytes = b[base + offset].view(torch.uint8)
             ref_bytes = ref.view(torch.uint8)

--- a/testing/python/language/test_tilelang_language_warp_vote.py
+++ b/testing/python/language/test_tilelang_language_warp_vote.py
@@ -422,35 +422,34 @@ def test_syncthreads_or():
 
 @tilelang.jit
 def kernel_match_any_sync():
-    """Lanes 0-15 share value 1; lanes 16-31 share value 2. match_any_sync
-    should return 0x0000FFFF for the first half and 0xFFFF0000 for the
-    second half."""
+    """Lanes 0-31 share value 1; lanes 32-63 share value 2."""
 
     @T.prim_func
     def main(
-        B: T.Tensor((32,), "int32"),
+        B: T.Tensor((64,), "int64"),
     ):
-        with T.Kernel(1, threads=32):
+        with T.Kernel(1, threads=64):
             tx = T.get_thread_binding()
-            value = T.if_then_else(tx < 16, 1, 2)
+            value = T.if_then_else(tx < 32, 1, 2)
             peers = T.match_any_sync(value)
-            B[tx] = T.cast(peers, "int32")
+            B[tx] = T.cast(peers, "int64")
 
     return main
 
 
 @tilelang.testing.requires_cuda
 def test_match_any_sync():
-    b = torch.zeros((32,), device="cuda", dtype=torch.int32)
+    b = torch.zeros((64,), device="cuda", dtype=torch.int64)
     kernel = kernel_match_any_sync()
     src = kernel.get_kernel_source()
     assert "__match_any_sync" in src, f"Expected __match_any_sync in source:\n{src}"
     kernel(b)
-    # Reinterpret the int32 buffer as uint32 to compare against bitmasks
-    # whose high bit is set (0xFFFF0000 overflows int32).
-    observed_u32 = b.to(torch.int64) & 0xFFFFFFFF
-    expected = torch.tensor([0x0000FFFF] * 16 + [0xFFFF0000] * 16, dtype=torch.int64, device="cuda")
-    assert torch.equal(observed_u32, expected), f"Expected {expected}, got {observed_u32}"
+    expected = torch.tensor(
+        [0x00000000FFFFFFFF] * 32 + [-0x0000000100000000] * 32,
+        dtype=torch.int64,
+        device="cuda",
+    )
+    assert torch.equal(b, expected), f"Expected {expected}, got {b}"
 
 
 # ---------------------------------------------------------------------------
@@ -460,16 +459,16 @@ def test_match_any_sync():
 
 @tilelang.jit
 def kernel_match_all_sync_true():
-    """All lanes share value 7 → match_all_sync returns the full mask."""
+    """All 64 lanes share value 7 → match_all_sync returns the full mask."""
 
     @T.prim_func
     def main(
-        B: T.Tensor((32,), "int32"),
+        B: T.Tensor((64,), "int64"),
     ):
-        with T.Kernel(1, threads=32):
+        with T.Kernel(1, threads=64):
             tx = T.get_thread_binding()
             result = T.match_all_sync(7)
-            B[tx] = T.cast(result, "int32")
+            B[tx] = T.cast(result, "int64")
 
     return main
 
@@ -480,26 +479,26 @@ def kernel_match_all_sync_false():
 
     @T.prim_func
     def main(
-        B: T.Tensor((32,), "int32"),
+        B: T.Tensor((64,), "int64"),
     ):
-        with T.Kernel(1, threads=32):
+        with T.Kernel(1, threads=64):
             tx = T.get_thread_binding()
             result = T.match_all_sync(tx)
-            B[tx] = T.cast(result, "int32")
+            B[tx] = T.cast(result, "int64")
 
     return main
 
 
 @tilelang.testing.requires_cuda
 def test_match_all_sync():
-    b = torch.zeros((32,), device="cuda", dtype=torch.int32)
+    b = torch.zeros((64,), device="cuda", dtype=torch.int64)
     kernel = kernel_match_all_sync_true()
     src = kernel.get_kernel_source()
     assert "__match_all_sync" in src, f"Expected __match_all_sync in source:\n{src}"
     kernel(b)
-    assert torch.all(b == -1), f"Expected all 0xFFFFFFFF (sign-extended -1), got {b}"
+    assert torch.all(b == -1), f"Expected all 0xFFFFFFFFFFFFFFFF, got {b}"
 
-    b2 = torch.zeros((32,), device="cuda", dtype=torch.int32)
+    b2 = torch.zeros((64,), device="cuda", dtype=torch.int64)
     kernel_match_all_sync_false()(b2)
     assert torch.all(b2 == 0), f"Expected all 0, got {b2}"
 

--- a/tilelang/language/builtin.py
+++ b/tilelang/language/builtin.py
@@ -913,10 +913,11 @@ def barrier_arrive(mbarrier: BarrierType):
     return mbarrier_arrive(mbarrier)
 
 
-# Full-warp mask as a proper uint32 TIR constant so the emitted C/C++ source
-# prints as `0xFFFFFFFFu` instead of `(int64_t)4294967295` after TIR widening.
+# Full-warp mask uses the target's native lane-mask width, avoiding signed
+# widening when the TIR constant is emitted as device source.
 if _IS_MACA_AVAILABLE:
-    _FULL_WARP_MASK = tirx.const(0xFFFFFFFF, "uint64")
+    # MACA executes 64-lane warps, so a full mask must include all 64 lanes.
+    _FULL_WARP_MASK = tirx.const(0xFFFFFFFFFFFFFFFF, "uint64")
     _DEFAULT_SHFL_WIDTH = 64
 else:
     _DEFAULT_SHFL_WIDTH = 32

--- a/tilelang/language/builtin.py
+++ b/tilelang/language/builtin.py
@@ -16,6 +16,16 @@ from tilelang.utils.language import retrieve_ptr, get_buffer_region_from_load, r
 
 _IS_MACA_AVAILABLE = check_maca_availability()
 
+# Full-warp mask uses the target's native lane-mask width, avoiding signed
+# widening when the TIR constant is emitted as device source.
+if _IS_MACA_AVAILABLE:
+    # MACA executes 64-lane warps, so a full mask must include all 64 lanes.
+    _FULL_WARP_MASK = tirx.const(0xFFFFFFFFFFFFFFFF, "uint64")
+    _DEFAULT_SHFL_WIDTH = 64
+else:
+    _DEFAULT_SHFL_WIDTH = 32
+    _FULL_WARP_MASK = tirx.const(0xFFFFFFFF, "uint32")
+
 
 def _normalize_index_arg(value: int | PrimExpr | None) -> PrimExpr | None:
     """
@@ -913,17 +923,6 @@ def barrier_arrive(mbarrier: BarrierType):
     return mbarrier_arrive(mbarrier)
 
 
-# Full-warp mask uses the target's native lane-mask width, avoiding signed
-# widening when the TIR constant is emitted as device source.
-if _IS_MACA_AVAILABLE:
-    # MACA executes 64-lane warps, so a full mask must include all 64 lanes.
-    _FULL_WARP_MASK = tirx.const(0xFFFFFFFFFFFFFFFF, "uint64")
-    _DEFAULT_SHFL_WIDTH = 64
-else:
-    _DEFAULT_SHFL_WIDTH = 32
-    _FULL_WARP_MASK = tirx.const(0xFFFFFFFF, "uint32")
-
-
 def _as_uint32_mask(mask: int | PrimExpr) -> PrimExpr:
     """Normalize a warp lane mask to a uint32 TIR expression.
 
@@ -1191,6 +1190,8 @@ def match_any_sync(
     the calling lane's value. Lowers to ``__match_any_sync`` on CUDA
     (compute capability >= 7.0). Not supported on HIP.
     """
+    if _IS_MACA_AVAILABLE:
+        return tirx.call_intrin("uint64", tirx.op.Op.get("tl.match_any_sync"), _as_uint64_mask(mask), value)
     return tirx.call_intrin("uint32", tirx.op.Op.get("tl.match_any_sync"), _as_uint32_mask(mask), value)
 
 
@@ -1205,6 +1206,8 @@ def match_all_sync(
     Callers can reconstruct the predicate as ``result != 0``. Not supported
     on HIP.
     """
+    if _IS_MACA_AVAILABLE:
+        return tirx.call_intrin("uint64", tirx.op.Op.get("tl.match_all_sync"), _as_uint64_mask(mask), value)
     return tirx.call_intrin("uint32", tirx.op.Op.get("tl.match_all_sync"), _as_uint32_mask(mask), value)
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added FP8 warp-shuffle overloads for MACA shuffle intrinsics.
- Updated MACA warp masks and shuffle widths to support 64 lanes.
- Corrected MACA `match_any_sync` and `match_all_sync` to use 64-bit masks and return types.
- Updated warp-sync and warp-vote tests from 32 lanes to 64 lanes.
- Removed the expected-failure marker for narrow FP8 shuffle tests.

## C++ style / lint notes

- The PR changes C++ code.
- It does not change rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) CI step is relevant.
- TLCPP003/TLCPP004 findings are advisory and do not indicate correctness or build failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->