### PR TITLE
[fix bug][MetaXGPU] fix test_math_fast_math.py case

### DIFF
--- a/src/maca/codegen/codegen_maca.cc
+++ b/src/maca/codegen/codegen_maca.cc
@@ -50,8 +50,32 @@ struct MACAMath {
         return name;
       case 32:
         return name + 'f';
-      case 16:
-        return 'h' + name;
+      case 16: {
+        if (name == "fabs") {
+          return "__habs";
+        } else if (name == "round") {
+          return "hrint";
+        } else {
+          return "h" + name;
+        }
+      }
+      default:
+        return "";
+      }
+    } else if (t.is_bfloat16()) {
+      if (name == "fabs") {
+        return "__habs";
+      } else if (name == "round") {
+        return "hrint";
+      } else {
+        return "h" + name;
+      }
+    } else if (t.is_int() || t.is_uint()) {
+      switch (t.bits()) {
+      case 32:
+        return "__" + name;
+      case 64:
+        return "__" + name + "ll";
       default:
         return "";
       }

--- a/testing/python/math/test_math_fast_math.py
+++ b/testing/python/math/test_math_fast_math.py
@@ -367,7 +367,6 @@ TAN_MATHOPS = [
 ]
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize(("name", "func"), TAN_MATHOPS, ids=[name for name, _ in TAN_MATHOPS])
 @pytest.mark.parametrize("dtype", [T.float16, T.bfloat16], ids=["float16", "bfloat16"])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated `MACAMath` half-precision mappings:
  - Maps `fabs` to `__habs`.
  - Maps `round` to `hrint`.
  - Uses the `h` prefix for other float16 and bfloat16 math functions.
- Removed the expected-failure marker from `test_tan_16bit_compiles_and_runs`.
- Integer math mappings remain unchanged.

## C++ style / lint notes

- The change touches C++ code but does not alter documented rules in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step may report advisory findings.
- No correctness or build issue is indicated by the changes. Advisory TLCPP003/TLCPP004 findings should not block this fix unless they identify a new API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->