### PR TITLE
[fix bug][MetaXGPU] fix test_tilelang_language_infinity.py case

### DIFF
--- a/src/tl_templates/maca/common.h
+++ b/src/tl_templates/maca/common.h
@@ -273,6 +273,12 @@ struct fp8_e4_t {
 
   TL_DEVICE explicit fp8_e4_t(value_t x) : v(x) {}
 
+  TL_DEVICE static fp8_e4_t bitcast(unsigned char raw) {
+    fp8_e4_t result;
+    result.v.__x = raw;
+    return result;
+  }
+
   template <class T,
             std::enable_if_t<!std::is_same_v<std::decay_t<T>, fp8_e4_t> &&
                                  std::is_constructible_v<value_t, T>,
@@ -311,6 +317,12 @@ struct fp8_e5_t {
   TL_DEVICE constexpr fp8_e5_t() : v{} {}
 
   TL_DEVICE explicit fp8_e5_t(value_t x) : v(x) {}
+
+  TL_DEVICE static fp8_e5_t bitcast(unsigned char raw) {
+    fp8_e5_t result;
+    result.v.__x = raw;
+    return result;
+  }
 
   template <class T,
             std::enable_if_t<!std::is_same_v<std::decay_t<T>, fp8_e5_t> &&

--- a/testing/python/language/test_tilelang_language_infinity.py
+++ b/testing/python/language/test_tilelang_language_infinity.py
@@ -27,8 +27,7 @@ def test_infinity():
     _test_infinity(T.bfloat16)
     _test_infinity(T.float32)
     _test_infinity(T.float64)
-    # TODO: xfail Issue encountered during upstream integration
-    # _test_infinity(T.float8_e5m2)
+    _test_infinity(T.float8_e5m2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `bitcast(unsigned char raw)` to `tl::fp8_e4_t` and `tl::fp8_e5_t`.
- The methods assign raw bits directly to the underlying value.
- Enabled the `T.float8_e5m2` infinity test.

## C++ style / lint notes

- The PR changes C++ code.
- The changes touch public FP8 APIs in `src/tl_templates/maca/common.h`.
- Review `docs/developer_guide/cpp_style.md` and the **C++ API Style Audit (warning only)** CI step for any advisory findings.
- Treat TLCPP003/TLCPP004 findings as warning-only unless they indicate an API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->