### PR TITLE
[fix bug][MetaXGPU] fix test_tilelang_codegen_line_directives.py case

### DIFF
--- a/src/maca/codegen/codegen_maca.cc
+++ b/src/maca/codegen/codegen_maca.cc
@@ -4051,6 +4051,8 @@ void CodeGenTileLangMACA::AddFunction(const GlobalVar &gvar,
   // Sync-insertion passes may split the block containing rng_init across
   // __syncthreads(), so a declaration emitted at the call site can go out
   // of scope before later rng_rand / rng_rand_float uses.
+  // Emit the function-entry #line before the pre-scan output below.
+  this->PreFunctionBody(f);
   rng_state_name_map_.clear();
   tirx::PostOrderVisit(f->body, [this](const ObjectRef &n) {
     const auto *call = n.as<CallNode>();
@@ -4073,7 +4075,6 @@ void CodeGenTileLangMACA::AddFunction(const GlobalVar &gvar,
                  << ";\n";
     rng_state_name_map_.emplace(call, std::move(name));
   });
-  this->PreFunctionBody(f);
   int func_scope = this->BeginScope();
   this->PrintStmt(f->body);
   this->EndScope(func_scope);

--- a/src/maca/codegen/codegen_maca.h
+++ b/src/maca/codegen/codegen_maca.h
@@ -17,14 +17,14 @@
 #include <string>
 #include <unordered_map>
 
-#include "target/source/codegen_c.h"
+#include "backend/common/codegen/codegen_c_line_directives.h"
 #include "tvm/ir/expr.h"
 #include "tvm/runtime/data_type.h"
 
 namespace tvm {
 namespace codegen {
 
-class CodeGenTileLangMACA final : public CodeGenC {
+class CodeGenTileLangMACA final : public CodeGenCWithLineDirectives {
 public:
   CodeGenTileLangMACA();
   std::string Finish();

--- a/src/maca/codegen/rt_mod_maca.cc
+++ b/src/maca/codegen/rt_mod_maca.cc
@@ -3,6 +3,7 @@
 
 #include "../runtime/maca_module.h"
 #include "codegen_maca.h"
+#include "op/builtin.h"
 #include "runtime/pack_args.h"
 #include "support/check.h"
 #include "transform/common/attr.h"
@@ -102,6 +103,10 @@ Module BuildTileLangMACA(IRModule mod, Target target) {
   bool output_ssa = false;
   CodeGenTileLangMACA cg;
   cg.Init(output_ssa);
+  cg.SetEmitLineDirectives(
+      tvm::transform::PassContext::Current()
+          ->GetConfig<Bool>(tl::kEmitLineDirectives, Bool(false))
+          .value());
 
   ValidateUniqueDeviceGlobalSymbols(mod);
   if (const auto f = Function::GetGlobal("tilelang_callback_maca_validate")) {
@@ -143,6 +148,10 @@ ffi::Module BuildTileLangMACAWithoutCompile(IRModule mod, Target target) {
   bool output_ssa = false;
   CodeGenTileLangMACA cg;
   cg.Init(output_ssa);
+  cg.SetEmitLineDirectives(
+      tvm::transform::PassContext::Current()
+          ->GetConfig<Bool>(tl::kEmitLineDirectives, Bool(false))
+          .value());
 
   ValidateUniqueDeviceGlobalSymbols(mod);
   if (const auto f =

--- a/testing/python/transform/test_tilelang_codegen_line_directives.py
+++ b/testing/python/transform/test_tilelang_codegen_line_directives.py
@@ -87,16 +87,15 @@ def test_line_directives_disabled_when_config_absent():
     assert "#line" not in artifact.kernel_source, artifact.kernel_source
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_line_directives_cuda_source():
-    """CUDA source (compile-only path, no GPU/nvcc) also maps statements."""
+    """MACA source (compile-only path, no GPU/nvcc) also maps statements."""
     target = {"kind": "maca"}
     config = {tilelang.PassConfigKey.TL_EMIT_LINE_DIRECTIVES: True}
     with tvm.transform.PassContext(opt_level=3, config=config), tvm.target.Target(target):
         artifact = tilelang.lower(vec_add_cuda, target=target)
     source = artifact.kernel_source
-    assert source is not None, "CUDA codegen produced no kernel source"
+    assert source is not None, "MACA codegen produced no kernel source"
     directives = _line_directives(source)
     store_line = _marker_line("line_marker_store_cuda")
     assert (store_line, __file__) in directives, f"store line {store_line} not mapped; directives: {directives}\n{source}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added line-directive support to `CodeGenTileLangMACA`.
- Enabled line-directive emission from the pass-context configuration.
- Moved the function-entry `#line` directive before RNG state declarations.
- Updated the MACA line-directive test to run without `xfail` and use MACA-specific messages.

## C++ style / lint notes

- The PR changes C++ code.
- The changes do not modify `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit is warning-only. Any TLCPP003/TLCPP004 findings should not block the PR unless they indicate a clear API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->