### PR TITLE
[fix bug][MetaXGPU] fix test_tilelang_language_func_attrs.py and test_tilelang_layout_inference_z3_context.py case

### DIFF
--- a/src/transform/make_packed_api.cc
+++ b/src/transform/make_packed_api.cc
@@ -345,7 +345,8 @@ std::vector<int> GetCalleeAllocatedOutputIndices(const PrimFunc &func) {
   }
 
   auto target = func->GetAttr<Target>(tvm::attr::kTarget);
-  if (!target || target.value()->kind->name != "cuda") {
+  if (!target || target.value()->kind->name != "cuda" &&
+                     target.value()->kind->name != "maca") {
     return {};
   }
   auto target_host = target.value()->GetHost();
@@ -438,6 +439,7 @@ MakePackedAPI(PrimFunc func,
   // The device context
   Var device_id("dev_id");
   Integer device_type(target_device_type);
+  PrimExpr allocator_device_type = device_type;
   // seq_init gives sequence of initialization
   // seq_check gives sequence of later checks after init
   std::vector<Stmt> seq_init, seq_check, arg_buffer_declarations;
@@ -744,9 +746,23 @@ MakePackedAPI(PrimFunc func,
         Call(DataType::Int(32), builtin::tvm_struct_get(),
              {anchor_tensor, IntImm(DataType::Int(32), 0),
               IntImm(DataType::Int(32), builtin::kDLTensorDeviceType)});
-    seq_init.push_back(MakeAssertEQ(
-        anchor_device_type, IntImm(DataType::Int(32), device_type.IntValue()),
-        name_hint + ": allocator anchor has the wrong device type"));
+    allocator_device_type = anchor_device_type;
+    // PyTorch's MACA compatibility layer exports CUDA's DLPack device enum
+    // (kDLCUDA), while TileLang's MACA target uses kDLMACA.  Keep the target
+    // enum for code generation, but accept this producer-side alias at the
+    // allocator boundary.
+    PrimExpr anchor_device_type_matches_target =
+        anchor_device_type == IntImm(DataType::Int(32), device_type.IntValue());
+    if (target_device_type == DLDeviceType::kDLMACA) {
+      anchor_device_type_matches_target =
+          anchor_device_type_matches_target ||
+          anchor_device_type ==
+              IntImm(DataType::Int(32), DLDeviceType::kDLCUDA);
+    }
+    seq_init.push_back(AssertStmt(
+        anchor_device_type_matches_target, tvm::tirx::StringImm("RuntimeError"),
+        Array<tvm::tirx::StringImm>({tvm::tirx::StringImm(
+            name_hint + ": allocator anchor has the wrong device type")})));
     PrimExpr anchor_device_id =
         Call(DataType::Int(32), builtin::tvm_struct_get(),
              {anchor_tensor, IntImm(DataType::Int(32), 0),
@@ -910,7 +926,10 @@ MakePackedAPI(PrimFunc func,
       set_prototype_field(builtin::kDLTensorByteOffset,
                           IntImm(DataType::UInt(64), 0));
       set_prototype_field(builtin::kDLTensorDeviceId, device_id);
-      set_prototype_field(builtin::kDLTensorDeviceType, device_type);
+      // The DLPack allocator belongs to the producer represented by the
+      // anchor.  Passing its actual enum lets PyTorch's CUDA-masquerading
+      // MACA allocator consume the prototype (device type 2) correctly.
+      set_prototype_field(builtin::kDLTensorDeviceType, allocator_device_type);
       PrimExpr prototype = Call(
           DataType::Handle(), builtin::tvm_struct_get(),
           {output_prototype_storage, IntImm(DataType::Int(32), output_ordinal),

--- a/testing/python/language/test_tilelang_language_func_attrs.py
+++ b/testing/python/language/test_tilelang_language_func_attrs.py
@@ -8,7 +8,6 @@ from tilelang import language as T
 from tilelang.transform import PassConfigKey
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_out_idx_via_attr_lazy():
     """out_idx should be stored as PrimFunc attr when using T.empty + return."""
@@ -36,7 +35,6 @@ def test_out_idx_via_attr_lazy():
         rt_mod.get_function(f"{kernel.attrs['global_symbol']}_auto_output", query_imports=True)
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_empty_dynamic_shape_is_allocated_by_tvm_ffi():
     """T.empty shape expressions should be evaluated by the packed ABI binder."""
@@ -58,7 +56,6 @@ def test_empty_dynamic_shape_is_allocated_by_tvm_ffi():
     torch.testing.assert_close(b, a.repeat(3)[:75] + 1.0)
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_empty_dynamic_shape_from_scalar_uses_ffi_allocator_anchor():
     """Scalar-only kernels should still install Torch's FFI allocator."""
@@ -97,7 +94,6 @@ def test_empty_dynamic_shape_from_scalar_uses_ffi_allocator_anchor():
         ),
     ],
 )
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_empty_subbyte_output_uses_torch_storage_dtype(
     logical_dtype,
@@ -122,7 +118,6 @@ def test_empty_subbyte_output_uses_torch_storage_dtype(
     assert output.shape == expected_shape
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_empty_dynamic_subbyte_output_packs_symbolic_final_dimension():
     """Storage-shape packing should remain symbolic until the packed call."""
@@ -143,7 +138,6 @@ def test_empty_dynamic_subbyte_output_packs_symbolic_final_dimension():
     assert output.shape == (3, 11)
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_multiple_empty_outputs_are_returned_from_tvm_ffi():
     """Multiple FFI-allocated outputs should preserve TileLang's list API."""
@@ -233,7 +227,6 @@ def test_out_idx_conflict_detection():
         tilelang.compile(kernel, out_idx=[-1])
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_manual_out_idx_multiple_dynamic_outputs_are_allocated_by_tvm_ffi():
     """Manual output indices should share T.empty's native allocation ABI."""

--- a/testing/python/layout/test_tilelang_layout_inference_z3_context.py
+++ b/testing/python/layout/test_tilelang_layout_inference_z3_context.py
@@ -143,7 +143,6 @@ def test_grouped_layout_inference_uses_fresh_z3_context_per_kernel():
         assert kernel is not None
 
 
-@tilelang.testing.pytest.mark.xfail
 @tilelang.testing.requires_cuda
 def test_grouped_tvm_ffi_manual_out_idx_uses_callee_allocation():
     unit_items = [(0, {"size": 17}), (1, {"size": 23})]

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -151,7 +151,7 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
         # The native wrapper is currently emitted for CUDA with TileLang's C
         # host codegen. Other device and host backends retain the preallocated-
         # output path until they have equivalent result-slot lowering.
-        if self.target.kind.name != "cuda":
+        if self.target.kind.name not in ["cuda", "maca"]:
             return False
         target_host = self.target.host
         return target_host is not None and target_host.kind.name == "c"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Support the callee-allocated output ABI for both `cuda` and `maca` targets.
- Handle MACA tensors that use CUDA's DLPack device enum.
- Use the anchor tensor device type for the output prototype when required.
- Remove obsolete expected-failure markers from the affected TileLang tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->