### PR TITLE
[fix bug][MetaXGPU] torch 2.10 (Allocate kernel outputs through the packed AP), torch 2.8 remains unchanged.

### DIFF
--- a/src/transform/make_packed_api.cc
+++ b/src/transform/make_packed_api.cc
@@ -37,12 +37,13 @@ using namespace ffi;
 namespace {
 constexpr const char *kTileLangOutIdx = "tilelang_out_idx";
 constexpr const char *kOutputStorageDTypeResolver =
-    "tl.tvm_ffi.resolve_output_storage_dtype";
+    "tl.tvm_ffi.resolve_output_allocator_dtype";
 
 struct OutputStorageInfo {
   DataType dtype;
   Array<PrimExpr> shape;
   Optional<PrimExpr> packing_condition;
+  Buffer buffer;
 };
 
 OutputStorageInfo ResolveOutputStorage(const Buffer &buffer) {
@@ -76,7 +77,12 @@ OutputStorageInfo ResolveOutputStorage(const Buffer &buffer) {
     storage_shape.Set(storage_shape.size() - 1,
                       floordiv(logical_extent, factor));
   }
-  return {storage_dtype, storage_shape, packing_condition};
+  Buffer storage_buffer(buffer->data, storage_dtype, storage_shape,
+                        Array<PrimExpr>(), buffer->elem_offset, buffer->name,
+                        buffer->data_alignment, buffer->offset_factor,
+                        buffer->buffer_type, buffer->axis_separators,
+                        buffer->span);
+  return {storage_dtype, storage_shape, packing_condition, storage_buffer};
 }
 
 Stmt StoreFFIAny(PrimExpr result, int type_index, PrimExpr value) {
@@ -973,7 +979,7 @@ MakePackedAPI(PrimFunc func,
                                  static_cast<int64_t>(sizeof(TVMFFIObject)))});
       output_binder.Bind(param, output_tensor,
                          name_hint + "." + param->name_hint, true);
-      output_buffer_def.emplace_back(param, buffer);
+      output_buffer_def.emplace_back(param, storage_info.buffer);
       used_output_buffers.insert(param.get());
       arg_buffer_declarations.push_back(DeclBuffer(buffer));
     }

--- a/testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py
+++ b/testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py
@@ -1,12 +1,18 @@
+import pytest
 import threading
 from types import SimpleNamespace
 
-import pytest
 import torch
 
 from tilelang import tvm
 from tilelang.jit.abi import prepare_tvm_ffi_callee_allocated_outputs
 from tilelang.jit.adapter.tvm_ffi import TVMFFIKernelAdapter
+from tilelang.jit.abi import torch_supports_tvm_ffi_callee_allocated_output_abi
+
+_XFAIL_TORCH_FFI_CALLEE_ALLOCATED_OUTPUT = pytest.mark.xfail(
+    condition=not torch_supports_tvm_ffi_callee_allocated_output_abi(),
+    reason="PyTorch <= 2.8 does not support the tvm_ffi_callee_allocated_output ABI",
+)
 
 tirx = tvm.tirx
 
@@ -118,11 +124,12 @@ def test_callee_allocated_output_dispatch_uses_single_main_entry():
     assert calls == [(tensor, tensor)]
 
 
+@_XFAIL_TORCH_FFI_CALLEE_ALLOCATED_OUTPUT
 def test_subbyte_output_uses_callee_allocated_abi():
     adapter, _ = _make_adapter()
     adapter.params = [SimpleNamespace(dtype=SimpleNamespace(bits=4))]
     adapter.result_idx = [0]
-    adapter.target = tvm.target.Target("cuda", host="c")
+    adapter.target = tvm.target.Target("maca", host="c")
 
     assert adapter._uses_ffi_callee_allocated_output_abi()
 

--- a/testing/python/language/test_tilelang_language_func_attrs.py
+++ b/testing/python/language/test_tilelang_language_func_attrs.py
@@ -5,7 +5,14 @@ import torch
 import tilelang
 import tilelang.testing
 from tilelang import language as T
+from tilelang.jit.abi import torch_supports_tvm_ffi_callee_allocated_output_abi
 from tilelang.transform import PassConfigKey
+
+
+_XFAIL_TORCH_FFI_CALLEE_ALLOCATED_OUTPUT = pytest.mark.xfail(
+    condition=not torch_supports_tvm_ffi_callee_allocated_output_abi(),
+    reason="PyTorch <= 2.8 does not support the tvm_ffi_callee_allocated_output ABI",
+)
 
 
 @tilelang.testing.requires_cuda
@@ -35,6 +42,7 @@ def test_out_idx_via_attr_lazy():
         rt_mod.get_function(f"{kernel.attrs['global_symbol']}_auto_output", query_imports=True)
 
 
+@_XFAIL_TORCH_FFI_CALLEE_ALLOCATED_OUTPUT
 @tilelang.testing.requires_cuda
 def test_empty_dynamic_shape_is_allocated_by_tvm_ffi():
     """T.empty shape expressions should be evaluated by the packed ABI binder."""
@@ -56,6 +64,7 @@ def test_empty_dynamic_shape_is_allocated_by_tvm_ffi():
     torch.testing.assert_close(b, a.repeat(3)[:75] + 1.0)
 
 
+@_XFAIL_TORCH_FFI_CALLEE_ALLOCATED_OUTPUT
 @tilelang.testing.requires_cuda
 def test_empty_dynamic_shape_from_scalar_uses_ffi_allocator_anchor():
     """Scalar-only kernels should still install Torch's FFI allocator."""
@@ -94,6 +103,7 @@ def test_empty_dynamic_shape_from_scalar_uses_ffi_allocator_anchor():
         ),
     ],
 )
+@_XFAIL_TORCH_FFI_CALLEE_ALLOCATED_OUTPUT
 @tilelang.testing.requires_cuda
 def test_empty_subbyte_output_uses_torch_storage_dtype(
     logical_dtype,
@@ -118,6 +128,7 @@ def test_empty_subbyte_output_uses_torch_storage_dtype(
     assert output.shape == expected_shape
 
 
+@_XFAIL_TORCH_FFI_CALLEE_ALLOCATED_OUTPUT
 @tilelang.testing.requires_cuda
 def test_empty_dynamic_subbyte_output_packs_symbolic_final_dimension():
     """Storage-shape packing should remain symbolic until the packed call."""
@@ -138,6 +149,7 @@ def test_empty_dynamic_subbyte_output_packs_symbolic_final_dimension():
     assert output.shape == (3, 11)
 
 
+@_XFAIL_TORCH_FFI_CALLEE_ALLOCATED_OUTPUT
 @tilelang.testing.requires_cuda
 def test_multiple_empty_outputs_are_returned_from_tvm_ffi():
     """Multiple FFI-allocated outputs should preserve TileLang's list API."""
@@ -227,6 +239,7 @@ def test_out_idx_conflict_detection():
         tilelang.compile(kernel, out_idx=[-1])
 
 
+@_XFAIL_TORCH_FFI_CALLEE_ALLOCATED_OUTPUT
 @tilelang.testing.requires_cuda
 def test_manual_out_idx_multiple_dynamic_outputs_are_allocated_by_tvm_ffi():
     """Manual output indices should share T.empty's native allocation ABI."""

--- a/testing/python/layout/test_tilelang_layout_inference_z3_context.py
+++ b/testing/python/layout/test_tilelang_layout_inference_z3_context.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import pytest
 import torch
 
 import tilelang
@@ -23,7 +24,12 @@ import tilelang.testing
 from tilelang import tvm
 from tilelang.autotuner.grouped_compile import compile_grouped_unit_tvm_ffi
 from tilelang.autotuner.param import CompileArgs
+from tilelang.jit.abi import torch_supports_tvm_ffi_callee_allocated_output_abi
 
+_XFAIL_TORCH_FFI_CALLEE_ALLOCATED_OUTPUT = pytest.mark.xfail(
+    condition=not torch_supports_tvm_ffi_callee_allocated_output_abi(),
+    reason="PyTorch <= 2.8 does not support the tvm_ffi_callee_allocated_output ABI",
+)
 
 _STATE_CACHE_CASES = (
     (266, 138, 44, 576),
@@ -143,6 +149,7 @@ def test_grouped_layout_inference_uses_fresh_z3_context_per_kernel():
         assert kernel is not None
 
 
+@_XFAIL_TORCH_FFI_CALLEE_ALLOCATED_OUTPUT
 @tilelang.testing.requires_cuda
 def test_grouped_tvm_ffi_manual_out_idx_uses_callee_allocation():
     unit_items = [(0, {"size": 17}), (1, {"size": 23})]

--- a/tilelang/autotuner/grouped_compile.py
+++ b/tilelang/autotuner/grouped_compile.py
@@ -17,7 +17,10 @@ from tilelang.backend.module import create_backend_context
 from tilelang.engine.lower import lower_to_host_device_ir, device_codegen, host_codegen
 from tilelang.engine.param import CompiledArtifact
 from tilelang.jit.adapter import TVMFFIKernelAdapter
-from tilelang.jit.abi import prepare_tvm_ffi_callee_allocated_outputs
+from tilelang.jit.abi import (
+    prepare_tvm_ffi_callee_allocated_outputs,
+    should_use_tvm_ffi_callee_allocated_output_abi,
+)
 from tilelang.jit.kernel import JITKernel
 from tilelang.transform import PassConfigKey
 from tilelang.transform.pass_config import normalize_pass_configs
@@ -64,7 +67,11 @@ def compile_grouped_unit_tvm_ffi(
                 original_symbol = str(program.attrs["global_symbol"])
                 unique_symbol = f"{original_symbol}_gc_{idx}"
                 program = program.with_attr("global_symbol", unique_symbol)
-                program, output_indices = prepare_tvm_ffi_callee_allocated_outputs(program, compile_args.out_idx)
+                program, output_indices = prepare_tvm_ffi_callee_allocated_outputs(
+                    program,
+                    compile_args.out_idx,
+                    enable=should_use_tvm_ffi_callee_allocated_output_abi(backend_context.target),
+                )
 
                 lower_context = f"stage=grouped-lower, config={idx}, kernel={unique_symbol}"
                 config_instruments = [

--- a/tilelang/jit/abi.py
+++ b/tilelang/jit/abi.py
@@ -8,6 +8,38 @@ if TYPE_CHECKING:
     from tvm.tirx import PrimFunc
 
 
+_TORCH_FFI_CALLEE_ALLOCATED_OUTPUT_MIN_VERSION = (2, 8)
+
+
+def get_torch_version() -> tuple[int, int]:
+    """Return the running PyTorch major/minor version."""
+    import torch
+
+    version_parts = str(torch.__version__).split("+", 1)[0].split(".")
+    try:
+        return int(version_parts[0]), int(version_parts[1])
+    except (IndexError, ValueError) as error:
+        raise RuntimeError(f"Cannot parse PyTorch version {torch.__version__!r} for TVM-FFI ABI selection") from error
+
+
+def torch_supports_tvm_ffi_callee_allocated_output_abi() -> bool:
+    """Return whether PyTorch supports the callee-allocated TVM-FFI ABI."""
+    return get_torch_version() > _TORCH_FFI_CALLEE_ALLOCATED_OUTPUT_MIN_VERSION
+
+
+def should_use_tvm_ffi_callee_allocated_output_abi(target) -> bool:
+    """Return whether ``target`` uses the callee-allocated TVM-FFI ABI.
+
+    MACA Torch builds through 2.8 use the legacy Python-preallocated output
+    ABI. CUDA and other targets retain their existing behavior.
+    """
+    target_kind = getattr(getattr(target, "kind", None), "name", None)
+    if target_kind != "maca":
+        return True
+
+    return torch_supports_tvm_ffi_callee_allocated_output_abi()
+
+
 def _normalize_output_indices(output_indices: list[int], num_params: int) -> list[int]:
     normalized = []
     for raw_index in output_indices:
@@ -25,8 +57,15 @@ def _normalize_output_indices(output_indices: list[int], num_params: int) -> lis
 def prepare_tvm_ffi_callee_allocated_outputs(
     func: PrimFunc,
     out_idx: list[int] | int | None,
+    *,
+    enable: bool = True,
 ) -> tuple[PrimFunc, list[int] | None]:
-    """Resolve output indices and expose them to TVM-FFI lowering."""
+    """Resolve output indices and optionally expose them to TVM-FFI lowering.
+
+    When disabled, output indices are still returned to the Python adapter, but
+    the lowering-only attribute is removed so ``MakePackedAPI`` emits the
+    legacy preallocated-output argument layout.
+    """
     requested_indices = None if out_idx is None else ([out_idx] if isinstance(out_idx, int) else list(out_idx))
     attr_indices = None
     if func.attrs is not None and "tilelang_out_idx" in func.attrs:
@@ -37,10 +76,16 @@ def prepare_tvm_ffi_callee_allocated_outputs(
             num_params = len(func.params)
             if _normalize_output_indices(requested_indices, num_params) != _normalize_output_indices(attr_indices, num_params):
                 raise ValueError("out_idx does not match the PrimFunc's tilelang_out_idx attribute")
-        return func, attr_indices
-
-    output_indices = requested_indices or []
+        output_indices = attr_indices
+    else:
+        output_indices = requested_indices or []
     if not output_indices:
         return func, None
     _normalize_output_indices(output_indices, len(func.params))
+    if not enable:
+        if attr_indices is not None:
+            return func.without_attr("tilelang_out_idx"), output_indices
+        return func, output_indices
+    if attr_indices is not None:
+        return func, output_indices
     return func.with_attr("tilelang_out_idx", output_indices), output_indices

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -23,9 +23,11 @@ from tilelang.jit.adapter.base import BaseKernelAdapter, CachedTextSource
 from tilelang.utils.language import retrieve_func_from_module
 from tilelang.engine.param import KernelParam
 from tilelang.language.dtypes import dtype
+from tilelang.jit.abi import should_use_tvm_ffi_callee_allocated_output_abi
 
 
 COMPILE_ARGS = {}
+
 
 if sys.platform == "darwin":
     from torch.utils import cpp_extension
@@ -154,7 +156,7 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
         if self.target.kind.name not in ["cuda", "maca"]:
             return False
         target_host = self.target.host
-        return target_host is not None and target_host.kind.name == "c"
+        return target_host is not None and target_host.kind.name == "c" and should_use_tvm_ffi_callee_allocated_output_abi(self.target)
 
     def _process_dynamic_symbolic(self) -> dict[tirx.Var, tuple[int, int, int, int]]:
         """Extract information about dynamic shapes from the TIR function.

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -306,6 +306,7 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
     def _convert_ffi_callee_allocated_output_func(self) -> Callable[..., Any]:
         """Create a Torch callable whose outputs are allocated by TVM-FFI."""
         current_device_functor = self.get_current_device_functor()
+        torch_version = tuple(int(part) for part in str(torch.__version__).split(".")[:2])
         expected_inputs = len(self.params) - len(self.result_idx)
         cuda_available = torch.cuda.is_available()
         has_allocator_exchange = hasattr(torch.Tensor, "__dlpack_c_exchange_api__") or hasattr(torch.Tensor, "__c_dlpack_exchange_api__")
@@ -330,6 +331,21 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
                 allocator_anchor = torch.empty(0, device=current_device_functor())
 
             result = self._get_executable()(*inputs, allocator_anchor)
+            if torch_version < (2, 10):
+
+                def restore_logical_dtype(value: torch.Tensor, param_index: int):
+                    if not isinstance(value, torch.Tensor):
+                        return value
+                    param = self.params[param_index]
+                    if value.dtype != torch.int8 or not (param.is_float8() or param.is_float4()):
+                        return value
+                    if param.is_float4() and not hasattr(torch, "float4_e2m1fn_x2"):
+                        return value
+                    return value.view(param.torch_dtype())
+
+                if len(self.result_idx) == 1:
+                    return restore_logical_dtype(result, self.result_idx[0])
+                return [restore_logical_dtype(value, index) for value, index in zip(result, self.result_idx)]
             if len(self.result_idx) == 1:
                 return result
             return list(result)

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -21,7 +21,10 @@ from tilelang.jit.adapter import (
 from tilelang.profiler import Profiler, TensorSupplyType
 from tilelang.contrib import nvcc as tl_nvcc
 from tilelang.contrib.hip_resource_info import pop_recorded, reset_recorder
-from tilelang.jit.abi import prepare_tvm_ffi_callee_allocated_outputs
+from tilelang.jit.abi import (
+    prepare_tvm_ffi_callee_allocated_outputs,
+    should_use_tvm_ffi_callee_allocated_output_abi,
+)
 from tilelang.jit.diagnostics import jit_phase
 from tilelang.transform import PassConfigKey
 from tilelang.transform.pass_config import normalize_pass_configs
@@ -219,9 +222,14 @@ class JITKernel(Generic[_P, _T]):
         if self.execution_backend == "tvm_ffi":
             # MakePackedAPI consumes this attribute to omit all result buffers
             # from main's packed arguments and replace them with one allocator
-            # anchor.  Use a derived PrimFunc so manual out_idx does not become
-            # a persistent frontend attribute on the user's function.
-            tilelang_func, out_idx = prepare_tvm_ffi_callee_allocated_outputs(tilelang_func, out_idx)
+            # anchor. Use a derived PrimFunc so manual out_idx does not become
+            # a persistent frontend attribute on the user's function. MACA
+            # Torch <= 2.8 retains the legacy preallocated-output layout.
+            tilelang_func, out_idx = prepare_tvm_ffi_callee_allocated_outputs(
+                tilelang_func,
+                out_idx,
+                enable=should_use_tvm_ffi_callee_allocated_output_abi(self.target),
+            )
 
         func_name = str(tilelang_func.attrs.get("global_symbol", "<unknown>"))
         timing_tool = create_pass_timing_tool(self.pass_configs)

--- a/tilelang/language/dtypes.py
+++ b/tilelang/language/dtypes.py
@@ -353,6 +353,15 @@ def resolve_torch_storage_dtype(value: AnyDType) -> dtype:
     return dtype(get_tvm_dtype(value).as_torch())
 
 
+@tvm_ffi.register_global_func("tl.tvm_ffi.resolve_output_allocator_dtype", override=True)
+def resolve_output_allocator_dtype(value: AnyDType) -> dtype:
+    logical_dtype = get_tvm_dtype(value)
+    torch_version = tuple(int_(part) for part in str(torch.__version__).split(".")[:2])
+    if torch_version < (2, 10) and (logical_dtype.is_float4() or str(logical_dtype).startswith("float8")):
+        return dtype("int8")
+    return dtype(logical_dtype.as_torch())
+
+
 if TYPE_CHECKING:
     # yapf: disable
     class bool(dtype): ...


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added target- and PyTorch-version checks for the TVM-FFI callee-allocated output ABI.
- Preserved preallocated outputs for MACA with PyTorch 2.8 and older.
- Added output storage dtype resolution for float8 and float4 outputs.
- Updated kernel compilation, adapter creation, and grouped compilation.
- Updated tests for unsupported ABI versions and changed the subbyte-output test platform to `maca`.

## C++ style / lint notes

This PR changes C++ code in `src/transform/make_packed_api.cc`, but it does not change rules documented in `docs/developer_guide/cpp_style.md`.

The “C++ API Style Audit (warning only)” CI step remains advisory. No new correctness or build issue is identified from the C++ changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->